### PR TITLE
Fixes some static analyzer warnings.

### DIFF
--- a/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.m
+++ b/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.m
@@ -150,8 +150,6 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
                                                           
                                                            NSMutableArray *motionDayValues = [NSMutableArray new];
                                                           
-                                                          BOOL activityRangeTimeFound = NO;
-                                                          
                                                           for(CMMotionActivity *activity in activities)
                                                           {
                                                               
@@ -175,8 +173,6 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
                                                                       removeThis = [midnight timeIntervalSinceDate:lastActivity_started];
                                                                       
                                                                       activityLengthTime = activityLengthTime - removeThis;
-                                                                      
-                                                                      activityRangeTimeFound = YES;
                                                                   }
                                                                   
                                                                   //Look for walking moderate and high confidence
@@ -209,7 +205,7 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
                                                                   
                                                                   if(activity.confidence == CMMotionActivityConfidenceMedium || activity.confidence == CMMotionActivityConfidenceHigh) // 45 seconds
                                                                   {
-                                                                      totalModerateTime += fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
+                                                                      totalModerateTime += fabs(activityLength);
                                                                    
                                                                   }
                                                                 
@@ -260,42 +256,37 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
                                                               }
                                                               else if(lastMotionActivityType == MotionActivityUnknown)
                                                               {
+																  NSTimeInterval lastActivityDuration = fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
+																  
                                                                   if (activity.stationary)
                                                                   {
-                                                                      totalSedentaryTime += fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
-                                                                      
-                                                                      lastMotionActivityType = MotionActivityStationary;
+                                                                      totalSedentaryTime += lastActivityDuration;
                                                                       lastActivity_started = activity.startDate;
                                                                   }
                                                                   else if (activity.walking && activity.confidence == CMMotionActivityConfidenceLow)
                                                                   {
-                                                                      totalLightActivityTime += fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
-                                                                      lastMotionActivityType = MotionActivityWalking;
+                                                                      totalLightActivityTime += lastActivityDuration;
                                                                       lastActivity_started = activity.startDate;
                                                                   }
                                                                   else if (activity.walking)
                                                                   {
-                                                                      totalModerateTime += fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
-                                                                      lastMotionActivityType = MotionActivityWalking;
+																	  totalModerateTime += lastActivityDuration;
                                                                       lastActivity_started = activity.startDate;
                                                                   }
                                                                   else if (activity.running)
                                                                   {
-                                                                      totalRunningTime += fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
-                                                                      lastMotionActivityType = MotionActivityRunning;
+																	  totalRunningTime += lastActivityDuration;
                                                                       lastActivity_started = activity.startDate;
                                                                   }
                                                                   
                                                                   else if (activity.cycling)
                                                                   {
-                                                                      totalRunningTime += fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
-                                                                      lastMotionActivityType = MotionActivityCycling;
+																	  totalRunningTime += lastActivityDuration;
                                                                       lastActivity_started = activity.startDate;
                                                                   }
                                                                   else if (activity.automotive)
                                                                   {
-                                                                      totalSedentaryTime += fabs([lastActivity_started timeIntervalSinceDate:activity.startDate]);
-                                                                      lastMotionActivityType = MotionActivityAutomotive;
+																	  totalSedentaryTime += lastActivityDuration;
                                                                       lastActivity_started = activity.startDate;
                                                                   }
                                                                   
@@ -311,13 +302,6 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
                                                                   
                                                               }
                                                               else if (activity.walking)
-                                                              {
-                                                                  lastMotionActivityType = MotionActivityWalking;
-                                                                  lastActivity_started = activity.startDate;
-                                                                  
-                                                              }
-                                                              
-                                                              else if (activity.walking && activity.confidence == CMMotionActivityConfidenceLow)
                                                               {
                                                                   lastMotionActivityType = MotionActivityWalking;
                                                                   lastActivity_started = activity.startDate;

--- a/APCAppCore/APCAppCore/Library/Insights/APCInsights.m
+++ b/APCAppCore/APCAppCore/Library/Insights/APCInsights.m
@@ -391,7 +391,7 @@ NSString * const kAPCInsightDataCollectionIsCompletedNotification = @"APCInsight
     APCLogDebug(@"Insights: %@", insightPoints);
     
     NSString *caption = NSLocalizedString(@"Not enough data", @"Not enough data");
-    NSNumber *pointValue = @(0);
+    NSNumber *pointValue = nil;
     
     NSArray *goodPoints = [insightPoints filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(%K == %@) AND (%K <> %@)",
                                                                       kInsightDatasetIsGoodDayKey, @(YES),

--- a/APCAppCore/APCAppCore/Library/MedicationTrackerStorageClasses/APCMedTrackerInflatableItem+Helper.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackerStorageClasses/APCMedTrackerInflatableItem+Helper.m
@@ -109,13 +109,12 @@
                         [generatedObject setValue: value forKey: key];
                     }
                 }
-
-                APCMedTrackerInflatableItem *itemToSave = generatedObject;
+				
                 APCMedTrackerInflatableItem *existingObjectWithThisName = [self itemWithSameNameAs: generatedObject
                                                                                          inContext: context];
                 if (existingObjectWithThisName)
                 {
-                    itemToSave = existingObjectWithThisName;
+                    APCMedTrackerInflatableItem *itemToSave = existingObjectWithThisName;
 
                     for (NSString *key in incomingData.allKeys)
                     {

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
@@ -216,16 +216,6 @@
 
 - (void)postMessageForServiceType:(NSString *)type
 {
-    NSString *serviceName;
-    
-    if ([type isEqualToString:SLServiceTypeTwitter]){
-        serviceName = @"Twitter";
-    } else if ([type isEqualToString:SLServiceTypeFacebook]) {
-        serviceName = @"Facebook";
-    } else {
-        serviceName = @"";
-    }
-    
     SLComposeViewController *composeViewController = [SLComposeViewController composeViewControllerForServiceType:type];
     
     [composeViewController setInitialText:self.shareMessage];

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCWebViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCWebViewController.m
@@ -39,7 +39,8 @@
 
 @implementation APCWebViewController
 
--(void)viewDidLoad{
+- (void)viewDidLoad {
+	[super viewDidLoad];
     self.webview.delegate = self;
     self.webview.alpha = 0.0;
     

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -508,8 +508,6 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     
                     NSInteger defaultIndexOfMyHeightInFeet = 5;
                     NSInteger defaultIndexOfMyHeightInInches = 0;
-                    NSInteger indexOfMyHeightInFeet = defaultIndexOfMyHeightInFeet;
-                    NSInteger indexOfMyHeightInInches = defaultIndexOfMyHeightInInches;
                     
                     double usersHeight = [APCUser heightInInches:self.user.height];
                     
@@ -521,8 +519,8 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                         NSArray *allPossibleHeightsInFeet = field.pickerData [0];
                         NSArray *allPossibleHeightsInInches = field.pickerData [1];
                         
-                        indexOfMyHeightInFeet = [allPossibleHeightsInFeet indexOfObject: feet];
-                        indexOfMyHeightInInches = [allPossibleHeightsInInches indexOfObject: inches];
+                        NSInteger indexOfMyHeightInFeet = [allPossibleHeightsInFeet indexOfObject: feet];
+                        NSInteger indexOfMyHeightInInches = [allPossibleHeightsInInches indexOfObject: inches];
                         
                         if (indexOfMyHeightInFeet == NSNotFound)
                         {
@@ -1664,17 +1662,13 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     ORKTaskViewController*  consentVC = [[ORKTaskViewController alloc] initWithTask:task taskRunUUID:[NSUUID UUID]];
     
     consentVC.navigationBar.topItem.title = NSLocalizedString(@"Consent", nil);
+	consentVC.delegate = self;
     
-    ORKTaskViewController *delegateConsentVC = [((APCAppDelegate *)[UIApplication sharedApplication].delegate) consentViewController];
+    NSUInteger subviewsCount = consentVC.view.subviews.count;
+    UILabel *watermarkLabel = [APCExampleLabel watermarkInRect:consentVC.view.bounds
+                                                    withCenter:consentVC.view.center];
     
-    delegateConsentVC = consentVC;
-    delegateConsentVC.delegate = self;
-    
-    NSUInteger subviewsCount = delegateConsentVC.view.subviews.count;
-    UILabel *watermarkLabel = [APCExampleLabel watermarkInRect:delegateConsentVC.view.bounds
-                                                    withCenter:delegateConsentVC.view.center];
-    
-    [delegateConsentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
+    [consentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
     
     [self presentViewController:consentVC animated:YES completion:nil];
 }

--- a/APCAppCore/APCAppCore/UI/ViewControllers/Activity Tracking/APCActivityTrackingStepViewController.m
+++ b/APCAppCore/APCAppCore/UI/ViewControllers/Activity Tracking/APCActivityTrackingStepViewController.m
@@ -172,44 +172,16 @@ static NSInteger const kRegularFontSize = 17;
 - (IBAction)handleDays:(UISegmentedControl *)sender
 {
     APCAppDelegate *appDelegate = (APCAppDelegate *)[[UIApplication sharedApplication] delegate];
-    NSDate *startDate = nil;
-    NSDate *endDate = nil;
     
     switch (sender.selectedSegmentIndex) {
         case 0:
             self.allocationDataset = [appDelegate.sevenDayFitnessAllocationData yesterdaysAllocation];
-            
-            startDate = [[NSCalendar currentCalendar] dateBySettingHour:0
-                                                                         minute:0
-                                                                         second:0
-                                                                         ofDate:[self dateForSpan:-1]
-                                                                        options:0];
-            endDate = [[NSCalendar currentCalendar] dateBySettingHour:23
-                                                               minute:59
-                                                               second:0
-                                                               ofDate:startDate
-                                                              options:0];
-            
             break;
         case 1:
             self.allocationDataset = [appDelegate.sevenDayFitnessAllocationData todaysAllocation];
-            startDate = [[NSCalendar currentCalendar] dateBySettingHour:0
-                                                                 minute:0
-                                                                 second:0
-                                                                 ofDate:[NSDate date]
-                                                                options:0];
-
             break;
         default:
             self.allocationDataset = [appDelegate.sevenDayFitnessAllocationData weeksAllocation];
-            
-            startDate = [[NSCalendar currentCalendar] dateBySettingHour:0
-                                                                 minute:0
-                                                                 second:0
-                                                                 ofDate:self.allocationStartDate
-                                                                options:0];
-            
-
             break;
     }
     


### PR DESCRIPTION
Fixes some warnings found with Xcode 6.3.

Code in `APCMotionHistoryReporter.m` would be easier to maintain with less vertical whitespace.
