### PR TITLE
nil unsafe delegates and data sources at dealloc

### DIFF
--- a/APCAppCore/APCAppCore/Library/DataArchiverAndCollector/Trackers/APCCoreLocationTracker.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndCollector/Trackers/APCCoreLocationTracker.m
@@ -103,6 +103,7 @@ static NSString *kLon = @"lon";
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+	_locationManager.delegate = nil;
 }
 
 - (void)setupInitialLocationParameters
@@ -126,6 +127,7 @@ static NSString *kLon = @"lon";
     if ([CLLocationManager locationServicesEnabled] == YES)
     {
         APCLogDebug(@"Start location tracking");
+		self.locationManager.delegate = nil;
         self.locationManager = [[CLLocationManager alloc] init];
         self.locationManager.delegate = self;
 

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndCollector/Trackers/APCCoreLocationTracker.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndCollector/Trackers/APCCoreLocationTracker.m
@@ -103,7 +103,7 @@ static NSString *kLon = @"lon";
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-	_locationManager.delegate = nil;
+    _locationManager.delegate = nil;
 }
 
 - (void)setupInitialLocationParameters
@@ -127,7 +127,7 @@ static NSString *kLon = @"lon";
     if ([CLLocationManager locationServicesEnabled] == YES)
     {
         APCLogDebug(@"Start location tracking");
-		self.locationManager.delegate = nil;
+        self.locationManager.delegate = nil;
         self.locationManager = [[CLLocationManager alloc] init];
         self.locationManager.delegate = self;
 

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarViewController.m
@@ -100,6 +100,12 @@ static  CGFloat    kAPCMedicationRowHeight = 64.0;
 
 @implementation APCMedicationTrackerCalendarViewController
 
+- (void)dealloc {
+	_exScrollibur.delegate = nil;
+	_tabulator.delegate = nil;
+	_tabulator.dataSource = nil;
+}
+
 #pragma  mark  -  Table View Data Source Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *) __unused tableView

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarViewController.m
@@ -101,9 +101,9 @@ static  CGFloat    kAPCMedicationRowHeight = 64.0;
 @implementation APCMedicationTrackerCalendarViewController
 
 - (void)dealloc {
-	_exScrollibur.delegate = nil;
-	_tabulator.delegate = nil;
-	_tabulator.dataSource = nil;
+    _exScrollibur.delegate = nil;
+    _tabulator.delegate = nil;
+    _tabulator.dataSource = nil;
 }
 
 #pragma  mark  -  Table View Data Source Methods

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarWeeklyView.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarWeeklyView.m
@@ -104,6 +104,11 @@ static  NSString  *kThinSpaceEnDashJoiner     = @"\u2009\u2013\u2009";
     return self;
 }
 
+- (void)dealloc {
+	_leftSwiper.delegate = nil;
+	_rightSwiper.delegate = nil;
+}
+
 - (void)setupViews
 {
     {

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarWeeklyView.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerCalendarWeeklyView.m
@@ -105,8 +105,8 @@ static  NSString  *kThinSpaceEnDashJoiner     = @"\u2009\u2013\u2009";
 }
 
 - (void)dealloc {
-	_leftSwiper.delegate = nil;
-	_rightSwiper.delegate = nil;
+    _leftSwiper.delegate = nil;
+    _rightSwiper.delegate = nil;
 }
 
 - (void)setupViews

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerDetailViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerDetailViewController.m
@@ -77,8 +77,8 @@ static  CGFloat    kAPCMedicationRowHeight       = 64.0;
 @implementation APCMedicationTrackerDetailViewController
 
 - (void)dealloc {
-	_tabulator.delegate = nil;
-	_tabulator.dataSource = nil;
+    _tabulator.delegate = nil;
+    _tabulator.dataSource = nil;
 }
 
 #pragma  mark  -  Table View Data Source Methods

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerDetailViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingAppComponent/APCMedicationTrackerDetailViewController.m
@@ -76,6 +76,11 @@ static  CGFloat    kAPCMedicationRowHeight       = 64.0;
 
 @implementation APCMedicationTrackerDetailViewController
 
+- (void)dealloc {
+	_tabulator.delegate = nil;
+	_tabulator.dataSource = nil;
+}
+
 #pragma  mark  -  Table View Data Source Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *) __unused tableView

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationDosage/APCMedicationDosageViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationDosage/APCMedicationDosageViewController.m
@@ -58,6 +58,11 @@ static  CGFloat    kAPCMedicationRowHeight   = 64.0;
 
 @implementation APCMedicationDosageViewController
 
+- (void)dealloc {
+	_tabulator.delegate = nil;
+	_tabulator.dataSource = nil;
+}
+
 #pragma  mark  -  Navigation Bar Button Action Methods
 
 - (void)doneButtonTapped:(UIBarButtonItem *) __unused sender

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationDosage/APCMedicationDosageViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationDosage/APCMedicationDosageViewController.m
@@ -59,8 +59,8 @@ static  CGFloat    kAPCMedicationRowHeight   = 64.0;
 @implementation APCMedicationDosageViewController
 
 - (void)dealloc {
-	_tabulator.delegate = nil;
-	_tabulator.dataSource = nil;
+    _tabulator.delegate = nil;
+    _tabulator.dataSource = nil;
 }
 
 #pragma  mark  -  Navigation Bar Button Action Methods

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationFrequency/APCMedicationFrequencyViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationFrequency/APCMedicationFrequencyViewController.m
@@ -95,6 +95,11 @@ static  CGFloat    kAPCMedicationRowHeight          = 64.0;
 
 @implementation APCMedicationFrequencyViewController
 
+- (void)dealloc {
+	_tabulator.delegate = nil;
+	_tabulator.dataSource = nil;
+}
+
 #pragma  mark  -  Table View Data Source Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *) __unused tableView

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationFrequency/APCMedicationFrequencyViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationFrequency/APCMedicationFrequencyViewController.m
@@ -96,8 +96,8 @@ static  CGFloat    kAPCMedicationRowHeight          = 64.0;
 @implementation APCMedicationFrequencyViewController
 
 - (void)dealloc {
-	_tabulator.delegate = nil;
-	_tabulator.dataSource = nil;
+    _tabulator.delegate = nil;
+    _tabulator.dataSource = nil;
 }
 
 #pragma  mark  -  Table View Data Source Methods

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationLabel/APCMedicationColorViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationLabel/APCMedicationColorViewController.m
@@ -66,8 +66,8 @@ static  CGFloat    kAPCMedicationRowHeight   = 64.0;
 @implementation APCMedicationColorViewController
 
 - (void)dealloc {
-	_tabulator.delegate = nil;
-	_tabulator.dataSource = nil;
+    _tabulator.delegate = nil;
+    _tabulator.dataSource = nil;
 }
 
 #pragma  mark  -  Navigation Bar Button Action Methods

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationLabel/APCMedicationColorViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationLabel/APCMedicationColorViewController.m
@@ -65,6 +65,11 @@ static  CGFloat    kAPCMedicationRowHeight   = 64.0;
 
 @implementation APCMedicationColorViewController
 
+- (void)dealloc {
+	_tabulator.delegate = nil;
+	_tabulator.dataSource = nil;
+}
+
 #pragma  mark  -  Navigation Bar Button Action Methods
 
 - (IBAction)doneButtonTapped:(UIBarButtonItem *) __unused sender

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationName/APCMedicationNameViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationName/APCMedicationNameViewController.m
@@ -69,8 +69,8 @@ static  CGFloat    kAPCMedicationRowHeight   = 64.0;
 
 
 - (void)dealloc {
-	_tabulator.delegate = nil;
-	_tabulator.dataSource = nil;
+    _tabulator.delegate = nil;
+    _tabulator.dataSource = nil;
 }
 
 #pragma  mark  -  Navigation Bar Button Action Methods

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationName/APCMedicationNameViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationName/APCMedicationNameViewController.m
@@ -67,6 +67,12 @@ static  CGFloat    kAPCMedicationRowHeight   = 64.0;
 
 @implementation APCMedicationNameViewController
 
+
+- (void)dealloc {
+	_tabulator.delegate = nil;
+	_tabulator.dataSource = nil;
+}
+
 #pragma  mark  -  Navigation Bar Button Action Methods
 
 - (void)doneButtonTapped:(UIBarButtonItem *) __unused sender

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationSetup/APCMedicationTrackerSetupViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationSetup/APCMedicationTrackerSetupViewController.m
@@ -118,6 +118,13 @@ static  NSString  *addTableCategories[]           = { @"Select Name", @"Select F
 
 @implementation APCMedicationTrackerSetupViewController
 
+- (void)dealloc {
+	_setupTabulator.delegate = nil;
+	_setupTabulator.dataSource = nil;
+	_listTabulator.delegate = nil;
+	_listTabulator.dataSource = nil;
+}
+
 #pragma  mark  -  Table View Data Source Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *) __unused tableView

--- a/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationSetup/APCMedicationTrackerSetupViewController.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackingSetup/MedicationSetup/APCMedicationTrackerSetupViewController.m
@@ -119,10 +119,10 @@ static  NSString  *addTableCategories[]           = { @"Select Name", @"Select F
 @implementation APCMedicationTrackerSetupViewController
 
 - (void)dealloc {
-	_setupTabulator.delegate = nil;
-	_setupTabulator.dataSource = nil;
-	_listTabulator.delegate = nil;
-	_listTabulator.dataSource = nil;
+    _setupTabulator.delegate = nil;
+    _setupTabulator.dataSource = nil;
+    _listTabulator.delegate = nil;
+    _listTabulator.dataSource = nil;
 }
 
 #pragma  mark  -  Table View Data Source Methods

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParametersCell.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParametersCell.m
@@ -46,7 +46,7 @@ static CGFloat cellHeight = 114.0;
 @implementation APCParametersCell
 
 - (void)dealloc {
-	_parameterTextInput.delegate = nil;
+    _parameterTextInput.delegate = nil;
 }
 
 - (void)awakeFromNib {

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParametersCell.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParametersCell.m
@@ -45,6 +45,10 @@ static CGFloat cellHeight = 114.0;
 
 @implementation APCParametersCell
 
+- (void)dealloc {
+	_parameterTextInput.delegate = nil;
+}
+
 - (void)awakeFromNib {
     // Initialization code
     [self.parameterTextInput setDelegate:self];

--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
@@ -493,7 +493,8 @@ typedef NS_ENUM(NSUInteger, APCPermissionsErrorCode) {
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	_locationManager.delegate = nil;
 }
 
 @end

--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
@@ -493,8 +493,8 @@ typedef NS_ENUM(NSUInteger, APCPermissionsErrorCode) {
 
 - (void)dealloc
 {
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
-	_locationManager.delegate = nil;
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    _locationManager.delegate = nil;
 }
 
 @end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
@@ -56,8 +56,8 @@
 @implementation APCShareViewController
 
 - (void)dealloc {
-	_tableView.delegate = nil;
-	_tableView.dataSource = nil;
+    _tableView.delegate = nil;
+    _tableView.dataSource = nil;
 }
 
 - (void)viewDidLoad {
@@ -256,7 +256,7 @@
         default:
             break;
     }
-	controller.delegate = nil;
+    controller.delegate = nil;
     [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -275,7 +275,7 @@
         default:
             break;
     }
-	controller.delegate = nil;
+    controller.delegate = nil;
     [controller dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
@@ -55,6 +55,11 @@
 
 @implementation APCShareViewController
 
+- (void)dealloc {
+	_tableView.delegate = nil;
+	_tableView.dataSource = nil;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     
@@ -251,7 +256,7 @@
         default:
             break;
     }
-    
+	controller.delegate = nil;
     [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -270,7 +275,7 @@
         default:
             break;
     }
-    
+	controller.delegate = nil;
     [controller dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
@@ -42,6 +42,10 @@
 
 @implementation APCStudyDetailsViewController
 
+- (void)dealloc {
+	_webView.delegate = nil;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
@@ -43,7 +43,7 @@
 @implementation APCStudyDetailsViewController
 
 - (void)dealloc {
-	_webView.delegate = nil;
+    _webView.delegate = nil;
 }
 
 - (void)viewDidLoad {

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
@@ -84,6 +84,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:APCConsentCompletedWithDisagreeNotification object:nil];
+	_collectionView.delegate = nil;
 }
 
 - (void) goBackToSignUpJoin: (NSNotification *) __unused notification
@@ -436,7 +437,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
         default:
             break;
     }
-    
+	controller.mailComposeDelegate = nil;
     [controller dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
@@ -84,7 +84,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:APCConsentCompletedWithDisagreeNotification object:nil];
-	_collectionView.delegate = nil;
+    _collectionView.delegate = nil;
 }
 
 - (void) goBackToSignUpJoin: (NSNotification *) __unused notification
@@ -437,7 +437,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
         default:
             break;
     }
-	controller.mailComposeDelegate = nil;
+    controller.mailComposeDelegate = nil;
     [controller dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
@@ -83,9 +83,9 @@ static NSString * const kStudyOverviewCellIdentifier = @"kStudyOverviewCellIdent
 
 - (void)dealloc
 {
-	[[NSNotificationCenter defaultCenter] removeObserver:self name:APCConsentCompletedWithDisagreeNotification object:nil];
-	_tableView.delegate = nil;
-	_tableView.dataSource = nil;
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:APCConsentCompletedWithDisagreeNotification object:nil];
+    _tableView.delegate = nil;
+    _tableView.dataSource = nil;
 }
 
 - (void)goBackToSignUpJoin:(NSNotification *) __unused notification

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
@@ -56,7 +56,6 @@ static NSString * const kStudyOverviewCellIdentifier = @"kStudyOverviewCellIdent
 
 @implementation APCStudyOverviewViewController
 
-
 #pragma mark - Lifecycle
 
 - (void)viewDidLoad {
@@ -84,7 +83,9 @@ static NSString * const kStudyOverviewCellIdentifier = @"kStudyOverviewCellIdent
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:APCConsentCompletedWithDisagreeNotification object:nil];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:APCConsentCompletedWithDisagreeNotification object:nil];
+	_tableView.delegate = nil;
+	_tableView.dataSource = nil;
 }
 
 - (void)goBackToSignUpJoin:(NSNotification *) __unused notification

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCWebViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCWebViewController.m
@@ -39,6 +39,10 @@
 
 @implementation APCWebViewController
 
+- (void)dealloc {
+	_webview.delegate = nil;
+}
+
 -(void)viewDidLoad{
     self.webview.delegate = self;
     self.webview.alpha = 0.0;

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCWebViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCWebViewController.m
@@ -40,7 +40,7 @@
 @implementation APCWebViewController
 
 - (void)dealloc {
-	_webview.delegate = nil;
+    _webview.delegate = nil;
 }
 
 -(void)viewDidLoad{

--- a/APCAppCore/APCAppCore/UI/Onboarding/EmailVerification/APCChangeEmailViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/EmailVerification/APCChangeEmailViewController.m
@@ -48,6 +48,10 @@ static NSString *kInternetNotAvailableErrorMessage2 = @"BackendServer Not Reacha
 
 @implementation APCChangeEmailViewController
 
+- (void)dealloc {
+	_emailTextField.delegate = nil;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     

--- a/APCAppCore/APCAppCore/UI/Onboarding/EmailVerification/APCChangeEmailViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/EmailVerification/APCChangeEmailViewController.m
@@ -49,7 +49,7 @@ static NSString *kInternetNotAvailableErrorMessage2 = @"BackendServer Not Reacha
 @implementation APCChangeEmailViewController
 
 - (void)dealloc {
-	_emailTextField.delegate = nil;
+    _emailTextField.delegate = nil;
 }
 
 - (void)viewDidLoad {

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCForgotPasswordViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCForgotPasswordViewController.m
@@ -45,6 +45,10 @@
 
 @implementation APCForgotPasswordViewController
 
+- (void)dealloc {
+	_emailTextField.delegate = nil;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCForgotPasswordViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCForgotPasswordViewController.m
@@ -46,7 +46,7 @@
 @implementation APCForgotPasswordViewController
 
 - (void)dealloc {
-	_emailTextField.delegate = nil;
+    _emailTextField.delegate = nil;
 }
 
 - (void)viewDidLoad

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCSignInViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCSignInViewController.m
@@ -47,8 +47,8 @@ static NSString * const kServerInvalidEmailErrorString = @"Invalid username or p
 @implementation APCSignInViewController
 
 - (void)dealloc {
-	_userHandleTextField.delegate = nil;
-	_passwordTextField.delegate = nil;
+    _userHandleTextField.delegate = nil;
+    _passwordTextField.delegate = nil;
 }
 
 #pragma mark - Life Cycle

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCSignInViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignIn/APCSignInViewController.m
@@ -46,6 +46,11 @@ static NSString * const kServerInvalidEmailErrorString = @"Invalid username or p
 
 @implementation APCSignInViewController
 
+- (void)dealloc {
+	_userHandleTextField.delegate = nil;
+	_passwordTextField.delegate = nil;
+}
+
 #pragma mark - Life Cycle
 
 - (void)viewDidLoad {

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
@@ -633,11 +633,13 @@ static CGFloat kHeaderHeight = 157.0f;
     self.profileImage = image;
     
     [self.profileImageButton setImage:image forState:UIControlStateNormal];
-    
+	
+	picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+	picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
@@ -633,13 +633,13 @@ static CGFloat kHeaderHeight = 157.0f;
     self.profileImage = image;
     
     [self.profileImageButton setImage:image forState:UIControlStateNormal];
-	
-	picker.delegate = nil;
+    
+    picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) imagePickerControllerDidCancel:(UIImagePickerController *)picker {
-	picker.delegate = nil;
+    picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpInfoViewController.m
@@ -55,8 +55,8 @@ static CGFloat const kHeaderHeight = 127.0f;
 @synthesize user = _user;
 
 - (void)dealloc {
-	_nameTextField.delegate = nil;
-	_emailTextField.delegate = nil;
+    _nameTextField.delegate = nil;
+    _emailTextField.delegate = nil;
 }
 
 - (void)viewDidLoad {

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpInfoViewController.m
@@ -54,6 +54,11 @@ static CGFloat const kHeaderHeight = 127.0f;
 @synthesize stepProgressBar;
 @synthesize user = _user;
 
+- (void)dealloc {
+	_nameTextField.delegate = nil;
+	_emailTextField.delegate = nil;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -73,7 +73,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 @implementation APCProfileViewController
 
 - (void)dealloc {
-	_nameTextField.delegate = nil;
+    _nameTextField.delegate = nil;
 }
 
 - (void)viewDidLoad {
@@ -1170,13 +1170,13 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     self.profileImage = image;
     [self.profileImageButton setImage:image forState:UIControlStateNormal];
     self.user.profileImage = UIImagePNGRepresentation(image);
-	picker.delegate = nil;
+    picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
-	picker.delegate = nil;
+    picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -72,6 +72,10 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 
 @implementation APCProfileViewController
 
+- (void)dealloc {
+	_nameTextField.delegate = nil;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     NSString *build = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
@@ -1166,11 +1170,13 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     self.profileImage = image;
     [self.profileImageButton setImage:image forState:UIControlStateNormal];
     self.user.profileImage = UIImagePNGRepresentation(image);
+	picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
+	picker.delegate = nil;
     [picker dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
@@ -56,8 +56,8 @@ static NSInteger kNumberOfRows = 2;
 @implementation APCSharingOptionsViewController
 
 - (void)dealloc {
-	_tableView.delegate = nil;
-	_tableView.dataSource = nil;
+    _tableView.delegate = nil;
+    _tableView.dataSource = nil;
 }
 
 - (void)viewDidLoad

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
@@ -55,6 +55,11 @@ static NSInteger kNumberOfRows = 2;
 
 @implementation APCSharingOptionsViewController
 
+- (void)dealloc {
+	_tableView.delegate = nil;
+	_tableView.dataSource = nil;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -48,6 +48,11 @@
 
 @implementation APCWithdrawSurveyViewController
 
+- (void)dealloc {
+	_tableView.delegate = nil;
+	_tableView.dataSource = nil;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -49,8 +49,8 @@
 @implementation APCWithdrawSurveyViewController
 
 - (void)dealloc {
-	_tableView.delegate = nil;
-	_tableView.dataSource = nil;
+    _tableView.delegate = nil;
+    _tableView.dataSource = nil;
 }
 
 - (void)viewDidLoad {

--- a/APCAppCore/APCAppCore/UI/TableViewCells/APCPickerTableViewCell.m
+++ b/APCAppCore/APCAppCore/UI/TableViewCells/APCPickerTableViewCell.m
@@ -43,6 +43,11 @@ NSString * const kAPCPickerTableViewCellIdentifier = @"APCPickerTableViewCell";
     self.pickerView.delegate = self;
 }
 
+- (void)dealloc {
+	_pickerView.delegate = nil;
+	_pickerView.dataSource = nil;
+}
+
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
 

--- a/APCAppCore/APCAppCore/UI/TableViewCells/APCPickerTableViewCell.m
+++ b/APCAppCore/APCAppCore/UI/TableViewCells/APCPickerTableViewCell.m
@@ -44,8 +44,8 @@ NSString * const kAPCPickerTableViewCellIdentifier = @"APCPickerTableViewCell";
 }
 
 - (void)dealloc {
-	_pickerView.delegate = nil;
-	_pickerView.dataSource = nil;
+    _pickerView.delegate = nil;
+    _pickerView.dataSource = nil;
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {

--- a/APCAppCore/APCAppCore/UI/TableViewCells/APCTextFieldTableViewCell.m
+++ b/APCAppCore/APCAppCore/UI/TableViewCells/APCTextFieldTableViewCell.m
@@ -63,6 +63,10 @@ NSString * const kAPCTextFieldTableViewCellIdentifier = @"APCTextFieldTableViewC
     [self setupAppearance];
 }
 
+- (void)dealloc {
+	_textField.delegate = nil;
+}
+
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
 

--- a/APCAppCore/APCAppCore/UI/TableViewCells/APCTextFieldTableViewCell.m
+++ b/APCAppCore/APCAppCore/UI/TableViewCells/APCTextFieldTableViewCell.m
@@ -64,7 +64,7 @@ NSString * const kAPCTextFieldTableViewCellIdentifier = @"APCTextFieldTableViewC
 }
 
 - (void)dealloc {
-	_textField.delegate = nil;
+    _textField.delegate = nil;
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/CommonTaskVCs/InstructionStepViewControllers/APCIntroductionViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/CommonTaskVCs/InstructionStepViewControllers/APCIntroductionViewController.m
@@ -59,8 +59,8 @@ static CGFloat      const kParagraphYPosition   = 20.0;
 @implementation APCIntroductionViewController
 
 - (void)dealloc {
-	_textScroller.delegate = nil;
-	_imageScroller.delegate = nil;
+    _textScroller.delegate = nil;
+    _imageScroller.delegate = nil;
 }
 
 #pragma  mark  -  Initialise Scroll View With Images

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/CommonTaskVCs/InstructionStepViewControllers/APCIntroductionViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/CommonTaskVCs/InstructionStepViewControllers/APCIntroductionViewController.m
@@ -58,6 +58,11 @@ static CGFloat      const kParagraphYPosition   = 20.0;
 
 @implementation APCIntroductionViewController
 
+- (void)dealloc {
+	_textScroller.delegate = nil;
+	_imageScroller.delegate = nil;
+}
+
 #pragma  mark  -  Initialise Scroll View With Images
 
 - (void)initialiseImageScrollView

--- a/APCAppCore/APCAppCore/UI/Views/APCPasscodeView.m
+++ b/APCAppCore/APCAppCore/UI/Views/APCPasscodeView.m
@@ -61,7 +61,7 @@ static CGFloat const kAPCPasscodeViewPinLength = 4;
 }
 
 - (void)dealloc {
-	_hiddenTextField.delegate = nil;
+    _hiddenTextField.delegate = nil;
 }
 
 - (void) addControls {

--- a/APCAppCore/APCAppCore/UI/Views/APCPasscodeView.m
+++ b/APCAppCore/APCAppCore/UI/Views/APCPasscodeView.m
@@ -60,6 +60,10 @@ static CGFloat const kAPCPasscodeViewPinLength = 4;
     return self;
 }
 
+- (void)dealloc {
+	_hiddenTextField.delegate = nil;
+}
+
 - (void) addControls {
     _digitViews = [NSMutableArray new];
     


### PR DESCRIPTION
This isn't a comprehensive review. There are probably some I missed.

System objects with unsafe references to their delegates may outlive the
lifetime of their delegates (eg when animating), sending messages to
deallocated instances. To be safe, if you assign your object as a delegate
to an unsafe delegate you also need to manually manage that unsafe
reference and prevent it from outliving your object.
