### PR TITLE
Set project settings to use 4 space indents rather than tabs

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -1965,6 +1965,7 @@
 				F5179B2A19D09128001DCCB7 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		F5179B2A19D09128001DCCB7 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
The project settings were for tabs, but the code appears to use 4 space indents.

This will make contributions more likely to match the indent style of the codebase.
