### PR TITLE
[JIRA-2796] Uploader now adds "item" field to JSON output, identifying the purpose of the upload.

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -85,7 +85,7 @@
 		3650C65B1AA29BB50075C935 /* APCCatastrophicErrorViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3650C6581AA29BB50075C935 /* APCCatastrophicErrorViewController.h */; };
 		3650C65C1AA29BB50075C935 /* APCCatastrophicErrorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3650C6591AA29BB50075C935 /* APCCatastrophicErrorViewController.m */; };
 		3650C65D1AA29BB50075C935 /* CatastrophicError.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3650C65A1AA29BB50075C935 /* CatastrophicError.storyboard */; };
-		3651424D1AA78521008A5CFA /* APCDataArchiverAndUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3651424B1AA78521008A5CFA /* APCDataArchiverAndUploader.h */; };
+		3651424D1AA78521008A5CFA /* APCDataArchiverAndUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3651424B1AA78521008A5CFA /* APCDataArchiverAndUploader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3651424E1AA78521008A5CFA /* APCDataArchiverAndUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 3651424C1AA78521008A5CFA /* APCDataArchiverAndUploader.m */; };
 		3654318D1A9A7BC200D66D97 /* APCMedTrackerInflatableItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3654318B1A9A7BC200D66D97 /* APCMedTrackerInflatableItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3654318E1A9A7BC200D66D97 /* APCMedTrackerInflatableItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 3654318C1A9A7BC200D66D97 /* APCMedTrackerInflatableItem.m */; };

--- a/APCAppCore/APCAppCore/APCAppCore.h
+++ b/APCAppCore/APCAppCore/APCAppCore.h
@@ -71,6 +71,7 @@ FOUNDATION_EXPORT const unsigned char APCAppCoreVersionString[];
 /* -------------------------------------
  Data Archiver & Passive Data Collectors
  --------------------------------------- */
+#import <APCAppCore/APCDataArchiverAndUploader.h>
 #import <APCAppCore/APCDataArchiver.h>
 #import <APCAppCore/APCPassiveDataCollector.h>
 #import <APCAppCore/APCDataTracker.h>

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.h
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.h
@@ -173,24 +173,25 @@
 
  (b) The caveat:  the dictionary will be converted to JSON in ways
  highly specific to this application suite and the fact that we're
- uploading to Sage.  For example, NSDate objects are will be
- converted to a specific ISO-8601 format (example:
- "2014-01-31T12:34:56-0800"), and strings which contain stringified
- arrays of integers will be converted to actual arrays of NSNumbers
- (because this is currently a problem happening far upstream from
- this uploader, in multiple places).
+ uploading to Sage.  For example, NSDate objects will be converted
+ to a specific ISO-8601 format (like "2014-01-31T12:34:56-0800"),
+ strings which contain arrays of integers will be converted to
+ arrays of actual integers, and CoreData objectIDs will be
+ converted to a UUID-like equivalent.
 
  @param dictionary  A dictionary to upload.  The dictionary will
  become a .json file, stored in a .zip file.  See the description
  of this method, above, for details.
 
- @param taskIdentifier  A string identifying the purpose of this
- upload.  I *think* this has to be something like a variable name.
- Specification in progress.  Required.
+ @param taskIdentifier  A human-readable string identifying the
+ purpose of this upload.  May be nil.  Note that the value, in
+ principle, should not be nil -- the point is to uniquely identify
+ your upload.  But that's a choice made by you and the people on
+ the server team who will receive your upload; the tool won't
+ prevent you from sending "nil" if you wish.
 
  @param taskRunUuid  A UUID representing a unique ID for this
- run of this particular task.  May be nil.  I think.
- Specification in progress.
+ run of the task identified by taskIdentifier.  May be nil.
  */
 + (void) uploadDictionary: (NSDictionary *) dictionary
        withTaskIdentifier: (NSString *) taskIdentifier
@@ -221,13 +222,15 @@
  
  @param path  The path of the file to upload.
 
- @param taskIdentifier  A string identifying the purpose of this
- upload.  Required.  I *think* this has to be something like a
- variable name, or a legal filename.  Specification in progress.
+ @param taskIdentifier  A human-readable string identifying the
+ purpose of this upload.  May be nil.  Note that the value, in
+ principle, should not be nil -- the point is to uniquely identify
+ your upload.  But that's a choice made by you and the people on
+ the server team who will receive your upload; the tool won't
+ prevent you from sending "nil" if you wish.
 
  @param taskRunUuid  A UUID representing a unique ID for this
- run of this particular task.  May be nil.  I think.
- Specification in progress.
+ run of the task identified by taskIdentifier.  May be nil.
 
  @param errorToReturn  A pointer to the variable for an error
  object.  If there's a problem *obtaining* the file, we'll return
@@ -263,13 +266,15 @@
  have different filenames-and-extensions -- please don't have
  two files named "temp.txt", for example.
 
- @param taskIdentifier  A string identifying the purpose of this
- upload.  Required.  I *think* this has to be something like a
- variable name, or a legal filename.  Specification in progress.
+ @param taskIdentifier  A human-readable string identifying the
+ purpose of this upload.  May be nil.  Note that the value, in
+ principle, should not be nil -- the point is to uniquely identify
+ your upload.  But that's a choice made by you and the people on
+ the server team who will receive your upload; the tool won't
+ prevent you from sending "nil" if you wish.
 
  @param taskRunUuid  A UUID representing a unique ID for this
- run of this particular task.  May be nil.  I think.
- Specification in progress.
+ run of the task identified by taskIdentifier.  May be nil.
 
  @param errorToReturn  A pointer to to the variable for an error
  object.  If there's a problem obtaining the file, we'll return
@@ -284,36 +289,6 @@
          withTaskIdentifier: (NSString *) taskIdentifier
              andTaskRunUuid: (NSUUID *) taskRunUuid
              returningError: (NSError * __autoreleasing *) errorToReturn;
-
-
-
-// ---------------------------------------------------------
-#pragma mark - Proposed Ideas (not yet implemented)
-// ---------------------------------------------------------
-
-/*
- Other ideas, based on other needs around the app.  Not yet implemented.
- (All this will eventually go into DataSubstrate.)
- 
- Please leave this commented-out block here, as we think about
- these options.
- */
-
-//    /** This represents what -[BaseTaskViewController processTaskResult] does now. */
-//    + (void) uploadResearchKitTaskResult: (id /* ORKTaskResult* */) taskResult;
-//
-//    /** For air-quality data:  encrypt the individual files inside the .zip file, as well as encrypting the whole package. */
-//    + (void)            uploadDictionary: (NSDictionary *) dictionary
-//         encryptingContentsBeforeZipping: (BOOL) shouldEncryptContentsFirst;
-//
-//    /** Er...  maybe this would be better?  Maybe it calls the above? */
-//    + (void) uploadAirQualityData: (NSDictionary *) airQualityStuff;
-//
-//    /** Catchall for uploading piles of random stuff?  Tapping test, 6-minute-walk test, etc.? */
-//    + (void) uploadDictionaries: (NSArray *) dictionaries
-//              withGroupFilename: (NSString *) filename
-//        encryptingContentsFirst: (BOOL) shouldEncryptContentsFirst;
-
 
 @end
 

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.m
@@ -100,47 +100,53 @@ typedef enum : NSInteger
     kErrorCantSerializeObject_Code,
     kErrorDontHaveAnyZippedFiles_Code,
     kErrorHaveDuplicateUploadableFilenames_Code,
+    kErrorInvalidTaskIdentifier_Code,
+    kErrorInvalidTaskRunUuid_Code,
     kErrorUploadFailed_Code,
 
 } APCErrorCode;
 
 
-static NSString * const kArchiveAndUploadErrorDomain                = @"ArchiveAndUpload";
+static NSString * const kArchiveAndUploadErrorDomain                    = @"ArchiveAndUpload";
 
-static NSString * const kErrorCantCreateArchiveFolder_Reason        = @"Can't create 'Archive' folder";
-static NSString * const kErrorCantCreateArchiveFolder_Suggestion    = @"Couldn't create the folder for preparing our .zip files.";
-static NSString * const kErrorCantCreateManifest_Reason             = @"Can't Create Manifest";
-static NSString * const kErrorCantCreateManifest_Suggestion_Format  = @"Couldn't create the manifest file entry (%@.%@) in the .zip file.";
-static NSString * const kErrorCantCreateUploadFolder_Reason         = @"Can't create 'Upload' folder";
-static NSString * const kErrorCantCreateUploadFolder_Suggestion     = @"Couldn't create the folder for saving files to be uploaded.";
-static NSString * const kErrorCantCreateWorkingDirectory_Reason     = @"Can't Create Working Folder";
-static NSString * const kErrorCantCreateWorkingDirectory_Suggestion = @"Couldn't create a folder in which to make our .zip file.";
-static NSString * const kErrorCantCreateZipFile_Reason              = @"Can't Create Archive in Memory";
-static NSString * const kErrorCantCreateZipFile_Suggestion          = @"We couldn't create the new, placeholder .zip file in RAM.  (We haven't even gotten to the 'save to disk' part.)";
-static NSString * const kErrorCantDeleteFileOrFolder_Reason         = @"Can't Delete File/Folder";
-static NSString * const kErrorCantDeleteFileOrFolder_Suggestion     = @"We couldn't delete a file/folder creating during the archiving process. See attached path and nested error, if any, for details.";
-static NSString * const kErrorCantEncryptFile_Reason                = @"Can't Encrypt Zip File";
-static NSString * const kErrorCantEncryptFile_Suggestion            = @"We couldn't encrypt the .zip file we need to upload.";
-static NSString * const kErrorCantFindDocumentsFolder_Reason        = @"Can't Find 'Documents' Folder";
-static NSString * const kErrorCantFindDocumentsFolder_Suggestion    = @"Couldn't find the user's 'documents' folder. This should never happen. Ahem.";
-static NSString * const kErrorCantFindEncryptedFile_Reason          = @"Can't Find Encrypted File";
-static NSString * const kErrorCantFindEncryptedFile_Suggestion      = @"We couldn't find the encrypted .zip file on disk (even though we seem to have successfully encrypted it...?).";
-static NSString * const kErrorCantFindUnencryptedFile_Reason        = @"Can't Find Unencrypted File";
-static NSString * const kErrorCantFindUnencryptedFile_Suggestion    = @"We couldn't find the unencrypted .zip file on disk (even though we seem to have successfully saved it...?).";
-static NSString * const kErrorCantInsertZipEntry_Reason             = @"Can't Insert Zip Entry";
-static NSString * const kErrorCantInsertZipEntry_Suggestion         = @"We couldn't add one of the .zippable items to the .zip file.";
-static NSString * const kErrorCantReadUnencryptedFile_Reason        = @"Can't Open Archive";
-static NSString * const kErrorCantReadUnencryptedFile_Suggestion    = @"Couldn't read the unencrypted .zip file we just tried to create.";
-static NSString * const kErrorCantSaveEncryptedFile_Reason          = @"Can't Save Encrypted File";
-static NSString * const kErrorCantSaveEncryptedFile_Suggestion      = @"We couldn't save the encrypted .zip file to disk.";
-static NSString * const kErrorCantSaveUnencryptedFile_Reason        = @"Can't Save Unencrypted File";
-static NSString * const kErrorCantSaveUnencryptedFile_Suggestion    = @"We couldn't save the unencrypted .zip file to disk.";
-static NSString * const kErrorCantSerializeObject_Reason            = @"Can't Serialize Object";
-static NSString * const kErrorCantSerializeObject_Suggestion        = @"We couldn't generate a JSON version of some piece of data.";
-static NSString * const kErrorDontHaveAnyZippedFiles_Reason         = @"Don't Have Files For Archive";
-static NSString * const kErrorDontHaveAnyZippedFiles_Suggestion     = @"Something went wrong. We don't seem to have any contents for this .zip file.";
-static NSString * const kErrorUploadFailed_Reason                   = @"Upload to Sage Failed";
-static NSString * const kErrorUploadFailed_Suggestion               = @"We got an error when uploading to Sage.  See the nested error for details.";
+static NSString * const kErrorCantCreateArchiveFolder_Reason            = @"Can't create 'Archive' folder";
+static NSString * const kErrorCantCreateArchiveFolder_Suggestion        = @"Couldn't create the folder for preparing our .zip files.";
+static NSString * const kErrorCantCreateManifest_Reason                 = @"Can't Create Manifest";
+static NSString * const kErrorCantCreateManifest_SuggestionFormat       = @"Couldn't create the manifest file entry (%@.%@) in the .zip file.";
+static NSString * const kErrorCantCreateUploadFolder_Reason             = @"Can't create 'Upload' folder";
+static NSString * const kErrorCantCreateUploadFolder_Suggestion         = @"Couldn't create the folder for saving files to be uploaded.";
+static NSString * const kErrorCantCreateWorkingDirectory_Reason         = @"Can't Create Working Folder";
+static NSString * const kErrorCantCreateWorkingDirectory_Suggestion     = @"Couldn't create a folder in which to make our .zip file.";
+static NSString * const kErrorCantCreateZipFile_Reason                  = @"Can't Create Archive in Memory";
+static NSString * const kErrorCantCreateZipFile_Suggestion              = @"We couldn't create the new, placeholder .zip file in RAM.  (We haven't even gotten to the 'save to disk' part.)";
+static NSString * const kErrorCantDeleteFileOrFolder_Reason             = @"Can't Delete File/Folder";
+static NSString * const kErrorCantDeleteFileOrFolder_Suggestion         = @"We couldn't delete a file/folder creating during the archiving process. See attached path and nested error, if any, for details.";
+static NSString * const kErrorCantEncryptFile_Reason                    = @"Can't Encrypt Zip File";
+static NSString * const kErrorCantEncryptFile_Suggestion                = @"We couldn't encrypt the .zip file we need to upload.";
+static NSString * const kErrorCantFindDocumentsFolder_Reason            = @"Can't Find 'Documents' Folder";
+static NSString * const kErrorCantFindDocumentsFolder_Suggestion        = @"Couldn't find the user's 'documents' folder. This should never happen. Ahem.";
+static NSString * const kErrorCantFindEncryptedFile_Reason              = @"Can't Find Encrypted File";
+static NSString * const kErrorCantFindEncryptedFile_Suggestion          = @"We couldn't find the encrypted .zip file on disk (even though we seem to have successfully encrypted it...?).";
+static NSString * const kErrorCantFindUnencryptedFile_Reason            = @"Can't Find Unencrypted File";
+static NSString * const kErrorCantFindUnencryptedFile_Suggestion        = @"We couldn't find the unencrypted .zip file on disk (even though we seem to have successfully saved it...?).";
+static NSString * const kErrorCantInsertZipEntry_Reason                 = @"Can't Insert Zip Entry";
+static NSString * const kErrorCantInsertZipEntry_Suggestion             = @"We couldn't add one of the .zippable items to the .zip file.";
+static NSString * const kErrorCantReadUnencryptedFile_Reason            = @"Can't Open Archive";
+static NSString * const kErrorCantReadUnencryptedFile_Suggestion        = @"Couldn't read the unencrypted .zip file we just tried to create.";
+static NSString * const kErrorCantSaveEncryptedFile_Reason              = @"Can't Save Encrypted File";
+static NSString * const kErrorCantSaveEncryptedFile_Suggestion          = @"We couldn't save the encrypted .zip file to disk.";
+static NSString * const kErrorCantSaveUnencryptedFile_Reason            = @"Can't Save Unencrypted File";
+static NSString * const kErrorCantSaveUnencryptedFile_Suggestion        = @"We couldn't save the unencrypted .zip file to disk.";
+static NSString * const kErrorCantSerializeObject_Reason                = @"Can't Serialize Object";
+static NSString * const kErrorCantSerializeObject_Suggestion            = @"We couldn't generate a JSON version of some piece of data.";
+static NSString * const kErrorDontHaveAnyZippedFiles_Reason             = @"Don't Have Files For Archive";
+static NSString * const kErrorDontHaveAnyZippedFiles_Suggestion         = @"Something went wrong. We don't seem to have any contents for this .zip file.";
+static NSString * const kErrorInvalidTaskIdentifier_Reason              = @"Invalid Task Identifier";
+static NSString * const kErrorInvalidTaskIdentifier_SuggestionFormat    = @"The task identifier you specified [%@] does not appear to be valid.  Please check the source code for the current requirements for this field.";
+static NSString * const kErrorInvalidTaskRunUuid_Reason                 = @"Invalid Task Run ID";
+static NSString * const kErrorInvalidTaskRunUuid_SuggestionFormat       = @"The 'task run ID' you specified [%@] doesn't appear to be valid.  Please check the source code for the current requirements for this field.";
+static NSString * const kErrorUploadFailed_Reason                       = @"Upload to Sage Failed";
+static NSString * const kErrorUploadFailed_Suggestion                   = @"We got an error when uploading to Sage.  See the nested error for details.";
 
 
 /*
@@ -209,6 +215,18 @@ static NSString *folderPathForUploadOperations = nil;
 
 @interface APCDataArchiverAndUploader ()
 @property (nonatomic, strong) NSArray               * dictionariesToUpload;
+
+/**
+ Name for the task being uploaded.  Needs to be a legal
+ C-style variable name.  I think.  Specification in progress.
+ */
+@property (nonatomic, strong) NSString              * taskIdentifier;
+
+/**
+ Unique ID for this particular run of the task identified
+ with taskIdentifier.  I think.  Specification in progress.
+ */
+@property (nonatomic, strong) NSUUID                * taskRunUuid;
 
 @property (nonatomic, strong) ZZArchive             * zipArchive;
 @property (nonatomic, strong) NSMutableArray        * zipEntries;
@@ -284,26 +302,38 @@ static NSString *folderPathForUploadOperations = nil;
 // ---------------------------------------------------------
 
 + (void) uploadDictionary: (NSDictionary *) dictionary
+       withTaskIdentifier: (NSString *) taskIdentifier
+           andTaskRunUuid: (NSUUID *) taskRunUuid
 {
-    APCDataArchiverAndUploader *archiverAndUploader = [[APCDataArchiverAndUploader alloc] initWithDictionariesToUpload: @[dictionary]];
+    APCDataArchiverAndUploader *archiverAndUploader = [[APCDataArchiverAndUploader alloc] initWithDictionariesToUpload: @[dictionary]
+                                                                                                        taskIdentifier: taskIdentifier
+                                                                                                           taskRunUuid: taskRunUuid];
 
     [self startOneUploadWithUploader: archiverAndUploader];
 }
 
 
 + (BOOL) uploadFileAtPath: (NSString *) path
+       withTaskIdentifier: (NSString *) taskIdentifier
+           andTaskRunUuid: (NSUUID *) taskRunUuid
            returningError: (NSError * __autoreleasing *) errorToReturn
 {
     BOOL result = [self uploadFilesAtPaths: @[path]
+                        withTaskIdentifier: taskIdentifier
+                            andTaskRunUuid: taskRunUuid
                             returningError: errorToReturn];
 
     return result;
 }
 
 + (BOOL) uploadFilesAtPaths: (NSArray *) paths
+         withTaskIdentifier: (NSString *) taskIdentifier
+             andTaskRunUuid: (NSUUID *) taskRunUuid
              returningError: (NSError * __autoreleasing *) errorToReturn
 {
-    APCDataArchiverAndUploader *archiverAndUploader = [[APCDataArchiverAndUploader alloc] initWithFilePathsToUpload: paths];
+    APCDataArchiverAndUploader *archiverAndUploader = [[APCDataArchiverAndUploader alloc] initWithFilePathsToUpload: paths
+                                                                                                     taskIdentifier: taskIdentifier
+                                                                                                        taskRunUuid: taskRunUuid];
 
     // Before we start the upload:  try to move the files to
     // a safe location we control.  Then the uploader will take
@@ -314,14 +344,14 @@ static NSString *folderPathForUploadOperations = nil;
 
     BOOL ableToMoveFile = [archiverAndUploader moveUploadableFilesToSafeLocationReturningError: & errorMovingFiles];
 
-    if (ableToMoveFile)
+    if (! ableToMoveFile)
     {
-        // This is the upload itself.
-        [self startOneUploadWithUploader: archiverAndUploader];
+        APCLogError2 (errorMovingFiles);
     }
     else
     {
-        APCLogError2 (errorMovingFiles);
+        // This is the upload itself.
+        [self startOneUploadWithUploader: archiverAndUploader];
     }
 
     if (errorToReturn != nil)
@@ -345,12 +375,20 @@ static NSString *folderPathForUploadOperations = nil;
 #pragma mark - Create one uploader
 // ---------------------------------------------------------
 
+/**
+ The real, bare-bones init.  Technically, this is the "designated
+ initializer."  However, the initializer you PROBABLY want is 
+ -initWithTaskIdentifier:andTaskRunUuid: , because that emits
+ a warning if you don't specify those fields.
+ */
 - (id) init
 {
     self = [super init];
 
     if (self)
     {
+        _taskIdentifier                     = nil;
+        _taskRunUuid                        = nil;
         _zipEntries                         = [NSMutableArray new];
         _fileInfoEntries                    = [NSMutableArray new];
         _countOfUnknownFileNames            = 0;
@@ -373,9 +411,26 @@ static NSString *folderPathForUploadOperations = nil;
     return self;
 }
 
-- (id) initWithDictionariesToUpload: (NSArray *) arrayOfDictionaries
+- (id) initWithTaskIdentifier: (NSString *) taskIdentifier
+               andTaskRunUuid: (NSUUID *) taskRunUuid
 {
     self = [self init];
+
+    if (self)
+    {
+        _taskIdentifier = taskIdentifier;
+        _taskRunUuid = taskRunUuid;
+    }
+
+    return self;
+}
+
+- (id) initWithDictionariesToUpload: (NSArray *) arrayOfDictionaries
+                     taskIdentifier: (NSString *) taskIdentifier
+                        taskRunUuid: (NSUUID *) taskRunUuid
+{
+    self = [self initWithTaskIdentifier: taskIdentifier
+                         andTaskRunUuid: taskRunUuid];
 
     if (self)
     {
@@ -386,8 +441,11 @@ static NSString *folderPathForUploadOperations = nil;
 }
 
 - (id) initWithFilePathsToUpload: (NSArray *) arrayOfFilePaths
+                  taskIdentifier: (NSString *) taskIdentifier
+                     taskRunUuid: (NSUUID *) taskRunUuid
 {
-    self = [self init];
+    self = [self initWithTaskIdentifier: taskIdentifier
+                         andTaskRunUuid: taskRunUuid];
 
     if (self)
     {
@@ -1406,10 +1464,20 @@ static NSString *folderPathForUploadOperations = nil;
     }
     else
     {
-        NSDictionary *zipArchiveManifest = @{ kAPCSerializedDataKey_Files      : self.fileInfoEntries,
-                                              kAPCSerializedDataKey_AppName    : appName,
-                                              kAPCSerializedDataKey_AppVersion : appVersion,
-                                              kAPCSerializedDataKey_PhoneInfo  : phoneInfo
+        // These two values should never be nil.  But if they
+        // are, ship them anyway, so that Sage can catch them
+        // and ask us about them.  The programmer who wrote this
+        // call to the uploader will then, appropriately, provide
+        // those values.
+        id taskIdentifier = self.taskIdentifier ?: [NSNull null];
+        id taskRunUuid    = self.taskRunUuid    ?: [NSNull null];
+
+        NSDictionary *zipArchiveManifest = @{ kAPCSerializedDataKey_Files       : self.fileInfoEntries,
+                                              kAPCSerializedDataKey_Item        : taskIdentifier,
+                                              kAPCSerializedDataKey_TaskRun     : taskRunUuid,
+                                              kAPCSerializedDataKey_AppName     : appName,
+                                              kAPCSerializedDataKey_AppVersion  : appVersion,
+                                              kAPCSerializedDataKey_PhoneInfo   : phoneInfo
                                               };
 
         NSError *errorCreatingManifest = nil;
@@ -1432,7 +1500,7 @@ static NSString *folderPathForUploadOperations = nil;
 
         if (! ableToCreateManifest)
         {
-            NSString *errorMessage = [NSString stringWithFormat: kErrorCantCreateManifest_Suggestion_Format,
+            NSString *errorMessage = [NSString stringWithFormat: kErrorCantCreateManifest_SuggestionFormat,
                                       kAPCNameOfIndexFile,
                                       kAPCFileExtension_JSON];
 
@@ -1887,29 +1955,6 @@ static NSString *folderPathForUploadOperations = nil;
         }
     }
 }
-
-
-
-
-// ---------------------------------------------------------
-#pragma mark - Proposed Ideas (not yet implemented)
-// ---------------------------------------------------------
-
-/*
- See explanations in the header file.
-
- These empty method bodies are just to calm down the compiler warnings.
- */
-+ (void) uploadResearchKitTaskResult: (id /* ORKTaskResult* */) __unused taskResult {}
-
-+ (void)           uploadDictionary: (NSDictionary *) __unused dictionary
-    encryptingContentsBeforeZipping: (BOOL)           __unused shouldEncryptContentsFirst {}
-
-+ (void) uploadAirQualityData: (NSDictionary *) __unused airQualityStuff {}
-
-+ (void) uploadDictionaries: (NSArray *)  __unused dictionaries
-          withGroupFilename: (NSString *) __unused filename
-    encryptingContentsFirst: (BOOL)       __unused shouldEncryptContentsFirst {}
 
 
 @end

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.m
@@ -375,20 +375,23 @@ static NSString *folderPathForUploadOperations = nil;
 #pragma mark - Create one uploader
 // ---------------------------------------------------------
 
-/**
- The real, bare-bones init.  Technically, this is the "designated
- initializer."  However, the initializer you PROBABLY want is 
- -initWithTaskIdentifier:andTaskRunUuid: , because that emits
- a warning if you don't specify those fields.
- */
 - (id) init
+{
+    self = [self initWithTaskIdentifier: nil
+                         andTaskRunUuid: nil];
+
+    return self;
+}
+
+- (id) initWithTaskIdentifier: (NSString *) taskIdentifier
+               andTaskRunUuid: (NSUUID *) taskRunUuid
 {
     self = [super init];
 
     if (self)
     {
-        _taskIdentifier                     = nil;
-        _taskRunUuid                        = nil;
+        _taskIdentifier                     = taskIdentifier;
+        _taskRunUuid                        = taskRunUuid;
         _zipEntries                         = [NSMutableArray new];
         _fileInfoEntries                    = [NSMutableArray new];
         _countOfUnknownFileNames            = 0;
@@ -406,20 +409,6 @@ static NSString *folderPathForUploadOperations = nil;
         _tempFilePathsToUpload              = nil;
         _pathToPrivateFolderOfFilesToUpload = nil;
         _privateFilePathsToUpload           = nil;
-    }
-
-    return self;
-}
-
-- (id) initWithTaskIdentifier: (NSString *) taskIdentifier
-               andTaskRunUuid: (NSUUID *) taskRunUuid
-{
-    self = [self init];
-
-    if (self)
-    {
-        _taskIdentifier = taskIdentifier;
-        _taskRunUuid = taskRunUuid;
     }
 
     return self;

--- a/APCAppCore/APCAppCore/Library/MedicationTrackerStorageClasses/APCMedTrackerPrescription+Helper.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackerStorageClasses/APCMedTrackerPrescription+Helper.m
@@ -741,7 +741,9 @@ static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
 
 + (void) sendRecordedActionToSage: (NSDictionary *) actionRecord
 {
-    [APCDataArchiverAndUploader uploadDictionary: actionRecord];
+    [APCDataArchiverAndUploader uploadDictionary: actionRecord
+                              withTaskIdentifier: actionRecord [@"item"]
+                                  andTaskRunUuid: nil];
 }
 
 + (void) recordActionForCreatingPrescription: (APCMedTrackerPrescription *) prescription

--- a/APCAppCore/APCAppCore/Library/MedicationTrackerStorageClasses/APCMedTrackerPrescription+Helper.m
+++ b/APCAppCore/APCAppCore/Library/MedicationTrackerStorageClasses/APCMedTrackerPrescription+Helper.m
@@ -45,22 +45,55 @@
 #import "APCMedTrackerDailyDosageRecord+Helper.h"
 #import "APCDataArchiverAndUploader.h"
 #import "APCLog.h"
+#import "APCJSONSerializer.h"
 
 
 /*
- Note to reviewers:
-
- - there are various hard-coded "errorDomains" and "errorCodes"
- throughout this file.  Acknowledged.  We're working toward a
- centralized way to manage those.
-
- - similarly, there's a utility method that creates an NSError
- object from a domain, a code, and a root-cause error.  We'll
- shortly move that to another class, too.
+ Please look at this collection of constants as a group, matching
+ the group of -recordXXXX: methods at the bottom of this file.
+ 
+ The idea:  as needed, we'll upload three "packages" of related
+ JSON data, corresponding to three user actions:  creating a
+ prescription, taking some medication specified in that prescription,
+ and cancelling the prescription.  The uploaded data comes from the
+ Prescription object chosen by the user.  These constants identify
+ that uploaded data.
  */
+static NSString * const kUploadablePackageIdentifierKey                     = @"userAction";
+static NSString * const kUploadablePackageCategoryKey                       = @"category";
+static NSString * const kUploadablePackageNameKey                           = @"name";
+static NSString * const kUploadablePackageVersionKey                        = @"version";
+static NSString * const kUploadablePackageCategory                          = @"medicationTracker";
+static NSString * const kUploadablePackageContents                          = @"prescription";
+static NSString * const kUploadablePackageCreatePrescriptionFileName        = @"medicationTracker_createPrescription";
+static NSString * const kUploadablePackageCreatePrescriptionName            = @"createPrescription";
+static NSUInteger const kUploadablePackageCreatePrescriptionSchemaVersion   = 1;
+static NSString * const kUploadablePackageExpirePrescriptionFileName        = @"medicationTracker_cancelPrescription";
+static NSString * const kUploadablePackageExpirePrescriptionName            = @"cancelPrescription";
+static NSUInteger const kUploadablePackageExpirePrescriptionSchemaVersion   = 1;
+static NSString * const kUploadablePackageRecordDosesFileName               = @"medicationTracker_recordTotalDailyDosesOfPrescription";
+static NSString * const kUploadablePackageRecordDosesName                   = @"recordTotalDailyDosesOfPrescription";
+static NSUInteger const kUploadablePackageRecordDosesSchemaVersion          = 1;
+static NSString * const kUploadableFieldUniqueIdKey                         = @"uniqueId";
+static NSString * const kUploadableFieldCreationDateKey                     = @"dateCreated";
+static NSString * const kUploadableFieldCancellationDateKey                 = @"dateCanceled";
+static NSString * const kUploadableFieldWeekdaysKey                         = @"daysOfTheWeek";
+static NSString * const kUploadableFieldTimesPerDayKey                      = @"numberOfTimesPerDay";
+static NSString * const kUploadableFieldMedicationNameKey                   = @"medicationName";
+static NSString * const kUploadableFieldDosageAmountKey                     = @"dosageAmount";
+static NSString * const kUploadableFieldDosageNameKey                       = @"dosageName";
+static NSString * const kUploadableFieldColorNameKey                        = @"colorName";
+static NSString * const kUploadableFieldDosageDateKey                       = @"dosageDate";
+static NSString * const kUploadableFieldDosesTakenKey                       = @"numberOfDosesTaken";
 
 
-static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
+/**
+ Field separator for the text format used as one input
+ to and output from this class, per the requirements of
+ the consumer class for which this class was built.
+ */
+static NSString * const kSeparatorForZeroBasedDaysOfTheWeek             = @",";
+
 
 
 @implementation APCMedTrackerPrescription (Helper)
@@ -326,9 +359,6 @@ static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
             }
             
                 
-            NSLog(@"###### Setting number of records for prescription [%@] on date [%@] to: [%@]. ######", blockSafePrescription, endUsersChosenDate, @(numberOfDosesTaken));
-
-
             NSString *errorDomainToReturn = nil;
             NSInteger errorCode = 0;
 
@@ -383,61 +413,21 @@ static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
     
     [APCMedTrackerDataStorageManager.defaultManager.queue addOperationWithBlock:^{
 
-        NSDate *startTime = [NSDate date];
-        
-//        NSManagedObjectContext *context = APCMedTrackerDataStorageManager.defaultManager.context;
-//
-//        // Gradually working toward normalizing our error-handling.
-//        NSError *coreDataError = nil;
-//        NSString *errorDomain = nil;
-//        NSInteger errorCode = 0;
-//
-//        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName: NSStringFromClass ([APCMedTrackerDailyDosageRecord class])];
-//
-//        NSString *nameOfDateGetterMethod = NSStringFromSelector (@selector (dateThisRecordRepresents));
-//
-//        request.predicate = [NSPredicate predicateWithFormat:
-//                             @"%K >= %@ && %K <= %@",
-//                             nameOfDateGetterMethod,
-//                             startDate.startOfDay,
-//                             nameOfDateGetterMethod,
-//                             endDate.endOfDay];
-//
-//        request.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey: nameOfDateGetterMethod
-//                                                                  ascending: YES]];
-//
-//        // "nil" means "a CoreData error occurred."  That's our default value.
-//        NSArray *dailyRecordsFound = [context executeFetchRequest: request error: & coreDataError];
-//
-//        if (dailyRecordsFound == nil)
-//        {
-//            errorDomain = @"MedTrackerDataStorageError";
-//            errorCode = 1;
-//
-//            // We'll return the error CoreData sent us as an underlyingError, shortly.
-//        }
-//        else
-//        {
-//            // Done!
-//        }
-        
-        
-        NSError    *coreDataError = nil;
-        NSString   *errorDomain = nil;
-        NSInteger  errorCode = 0;
-        
-        NSString *dateFieldName = NSStringFromSelector (@selector (dateThisRecordRepresents));
-        
-        NSPredicate *dateFilter = [NSPredicate predicateWithFormat: @"%K >= %@ AND %K <= %@",
-                                   dateFieldName,
-                                   startDate.startOfDay,
-                                   dateFieldName,
-                                   endDate.endOfDay];
-        
-        NSSet *filteredRecords = [self.actualDosesTaken filteredSetUsingPredicate: dateFilter];
-        NSArray *dailyRecordsFound = [filteredRecords allObjects];
+        NSDate      *startTime              = [NSDate date];
+        NSError     *coreDataError          = nil;
+        NSString    *errorDomain            = nil;
+        NSInteger   errorCode               = 0;
+        NSString    *dateFieldName          = NSStringFromSelector (@selector (dateThisRecordRepresents));
 
-        NSTimeInterval operationDuration = [[NSDate date] timeIntervalSinceDate: startTime];
+        NSPredicate *dateFilter             = [NSPredicate predicateWithFormat: @"%K >= %@ AND %K <= %@",
+                                               dateFieldName,
+                                               startDate.startOfDay,
+                                               dateFieldName,
+                                               endDate.endOfDay];
+
+        NSSet *filteredRecords              = [self.actualDosesTaken filteredSetUsingPredicate: dateFilter];
+        NSArray *dailyRecordsFound          = [filteredRecords allObjects];
+        NSTimeInterval operationDuration    = [[NSDate date] timeIntervalSinceDate: startTime];
 
         if (someQueue != nil && callbackBlock != NULL)
         {
@@ -475,19 +465,18 @@ static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
             NSInteger errorCode = 0;
             NSError *coreDataError = nil;
 
+
             //
-            // All this overhead (ahem:  "noise") for the following
-            // nearly-trivial operation:
+            // The point of this method:
             //
-            // Note:  there's also a -didStopUsingOnDoctorsOrders
-            // field.  I overengineered that.  Ahem.  We don't need it.
-            // We're purposely ignoring it.
-            //
+
             blockSafePrescription.dateStoppedUsing = [NSDate date];
-            
+
+
             //
             // Save it.
             //
+
             BOOL successfullySaved = [blockSafePrescription saveToPersistentStore: & coreDataError];
             
             if (successfullySaved)
@@ -739,32 +728,39 @@ static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
 #pragma mark - Data extracts to send to Sage
 // ---------------------------------------------------------
 
+/*
+ Please look at the next four methods as a group.
+ The first method uploads a JSON "package" specified by the last 3 methods.
+ The last 3 methods all create parallel structures, so that people reading
+ the uploaded data see how these pieces relate to each other.
+ */
+
 + (void) sendRecordedActionToSage: (NSDictionary *) actionRecord
 {
     [APCDataArchiverAndUploader uploadDictionary: actionRecord
-                              withTaskIdentifier: actionRecord [@"item"]
+                              withTaskIdentifier: actionRecord [kAPCSerializedDataKey_Item]
                                   andTaskRunUuid: nil];
 }
 
 + (void) recordActionForCreatingPrescription: (APCMedTrackerPrescription *) prescription
 {
     NSDictionary * result = @{
-                              @"item"           : @"medicationTracker_createPrescription",      // old filename entry.  I'm trying to propose some new ways to think about this.
+                              kAPCSerializedDataKey_Item      : kUploadablePackageCreatePrescriptionFileName,
 
-                              @"userAction"     : @{ @"category"    : @"medicationTracker",
-                                                     @"name"        : @"createPrescription",
-                                                     @"version"     : @(1)
-                                                     },
+                              kUploadablePackageIdentifierKey : @{ kUploadablePackageCategoryKey     : kUploadablePackageCategory,
+                                                                   kUploadablePackageNameKey         : kUploadablePackageCreatePrescriptionName,
+                                                                   kUploadablePackageVersionKey      : @(kUploadablePackageCreatePrescriptionSchemaVersion)
+                                                                   },
 
-                              @"prescription"   : @{ @"uniqueId"               : prescription.objectID,
-                                                     @"dateCreated"            : prescription.dateStartedUsing,
-                                                     @"daysOfTheWeek"          : prescription.zeroBasedDaysOfTheWeekAsArrayOfSortedShortNames,
-                                                     @"numberOfTimesPerDay"    : prescription.numberOfTimesPerDay,
-                                                     @"medicationName"         : prescription.medication.name,
-                                                     @"dosageAmount"           : prescription.dosage.amount,
-                                                     @"dosageName"             : prescription.dosage.name,
-                                                     @"colorName"              : prescription.color.name
-                                                     },
+                              kUploadablePackageContents      : @{ kUploadableFieldUniqueIdKey       : prescription.objectID,
+                                                                   kUploadableFieldCreationDateKey   : prescription.dateStartedUsing,
+                                                                   kUploadableFieldWeekdaysKey       : prescription.zeroBasedDaysOfTheWeekAsArrayOfSortedShortNames,
+                                                                   kUploadableFieldTimesPerDayKey    : prescription.numberOfTimesPerDay,
+                                                                   kUploadableFieldMedicationNameKey : prescription.medication.name,
+                                                                   kUploadableFieldDosageAmountKey   : prescription.dosage.amount,
+                                                                   kUploadableFieldDosageNameKey     : prescription.dosage.name,
+                                                                   kUploadableFieldColorNameKey      : prescription.color.name
+                                                                   },
                               };
 
     [self sendRecordedActionToSage: result];
@@ -773,16 +769,16 @@ static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
 + (void) recordActionForExpiringPrescription: (APCMedTrackerPrescription *) prescription
 {
     NSDictionary * result = @{
-                              @"item"         : @"medicationTracker_cancelPrescription",      // old filename entry.  I'm trying to propose some new ways to think about this.
+                              kAPCSerializedDataKey_Item      : kUploadablePackageExpirePrescriptionFileName,
 
-                              @"userAction"   : @{ @"category"      : @"medicationTracker",
-                                                   @"name"          : @"cancelPrescription",
-                                                   @"version"       : @(1),
-                                                   },
+                              kUploadablePackageIdentifierKey : @{ kUploadablePackageCategoryKey       : kUploadablePackageCategory,
+                                                                   kUploadablePackageNameKey           : kUploadablePackageExpirePrescriptionName,
+                                                                   kUploadablePackageVersionKey        : @(kUploadablePackageExpirePrescriptionSchemaVersion),
+                                                                   },
 
-                              @"prescription" : @{ @"uniqueId"      : prescription.objectID,
-                                                   @"dateCanceled"  : prescription.dateStoppedUsing,
-                                                   },
+                              kUploadablePackageContents      : @{ kUploadableFieldUniqueIdKey         : prescription.objectID,
+                                                                   kUploadableFieldCancellationDateKey : prescription.dateStoppedUsing,
+                                                                   },
                               };
 
     [self sendRecordedActionToSage: result];
@@ -793,17 +789,17 @@ static NSString * const kSeparatorForZeroBasedDaysOfTheWeek = @",";
                                forPrescription: (APCMedTrackerPrescription *) prescription
 {
     NSDictionary *result = @{
-                             @"item"         : @"medicationTracker_recordTotalDailyDosesOfPrescription",      // old filename entry.  I'm trying to propose some new ways to think about this.
+                             kAPCSerializedDataKey_Item      : kUploadablePackageRecordDosesFileName,
 
-                             @"userAction"   : @{ @"category"       : @"medicationTracker",
-                                                  @"name"           : @"recordTotalDailyDosesOfPrescription",
-                                                  @"version"        : @(1),
-                                                  },
+                             kUploadablePackageIdentifierKey : @{ kUploadablePackageCategoryKey  : kUploadablePackageCategory,
+                                                                  kUploadablePackageNameKey      : kUploadablePackageRecordDosesName,
+                                                                  kUploadablePackageVersionKey   : @(kUploadablePackageRecordDosesSchemaVersion),
+                                                                  },
 
-                             @"prescription" : @{ @"uniqueId"           : prescription.objectID,
-                                                  @"dosageDate"         : date,
-                                                  @"numberOfDosesTaken" : numberOfDosesTaken
-                                                  },
+                             kUploadablePackageContents      :  @{ kUploadableFieldUniqueIdKey   : prescription.objectID,
+                                                                   kUploadableFieldDosageDateKey : date,
+                                                                   kUploadableFieldDosesTakenKey : numberOfDosesTaken
+                                                                   },
                              };
 
     [self sendRecordedActionToSage: result];

--- a/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.h
@@ -41,18 +41,18 @@
  Imported (stolen, duplicated) from APCDataArchiver.
  Working on normalizing that.
  */
-static NSString * const kAPCSerializedDataKey_QuestionType            = @"questionType";
-static NSString * const kAPCSerializedDataKey_QuestionTypeName        = @"questionTypeName";
-static NSString * const kAPCSerializedDataKey_UserInfo                = @"userInfo";
-static NSString * const kAPCSerializedDataKey_Identifier              = @"identifier";
-static NSString * const kAPCSerializedDataKey_Item                    = @"item";
-static NSString * const kAPCSerializedDataKey_TaskRun                 = @"taskRun";
-static NSString * const kAPCSerializedDataKey_Files                   = @"files";
-static NSString * const kAPCSerializedDataKey_AppName                 = @"appName";
-static NSString * const kAPCSerializedDataKey_AppVersion              = @"appVersion";
-static NSString * const kAPCSerializedDataKey_FileInfoName            = @"filename";
-static NSString * const kAPCSerializedDataKey_FileInfoTimeStamp       = @"timestamp";
-static NSString * const kAPCSerializedDataKey_FileInfoContentType     = @"contentType";
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_QuestionType;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_QuestionTypeName;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_UserInfo;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_Identifier;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_Item;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_TaskRun;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_Files;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_AppName;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_AppVersion;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_FileInfoName;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_FileInfoTimeStamp;
+FOUNDATION_EXPORT NSString * const kAPCSerializedDataKey_FileInfoContentType;
 
 
 /**

--- a/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.h
@@ -46,6 +46,7 @@ static NSString * const kAPCSerializedDataKey_QuestionTypeName        = @"questi
 static NSString * const kAPCSerializedDataKey_UserInfo                = @"userInfo";
 static NSString * const kAPCSerializedDataKey_Identifier              = @"identifier";
 static NSString * const kAPCSerializedDataKey_Item                    = @"item";
+static NSString * const kAPCSerializedDataKey_TaskRun                 = @"taskRun";
 static NSString * const kAPCSerializedDataKey_Files                   = @"files";
 static NSString * const kAPCSerializedDataKey_AppName                 = @"appName";
 static NSString * const kAPCSerializedDataKey_AppVersion              = @"appVersion";

--- a/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.m
@@ -37,6 +37,31 @@
 #import <CoreData/CoreData.h>
 
 
+
+/**
+ Publicly-declared constants (in my header file).
+
+ These constants are used by a couple of different classes
+ which prepare stuff for me to serialize.
+
+ Imported (stolen, duplicated) from APCDataArchiver.
+ Working on normalizing that.
+ */
+NSString * const kAPCSerializedDataKey_QuestionType            = @"questionType";
+NSString * const kAPCSerializedDataKey_QuestionTypeName        = @"questionTypeName";
+NSString * const kAPCSerializedDataKey_UserInfo                = @"userInfo";
+NSString * const kAPCSerializedDataKey_Identifier              = @"identifier";
+NSString * const kAPCSerializedDataKey_Item                    = @"item";
+NSString * const kAPCSerializedDataKey_TaskRun                 = @"taskRun";
+NSString * const kAPCSerializedDataKey_Files                   = @"files";
+NSString * const kAPCSerializedDataKey_AppName                 = @"appName";
+NSString * const kAPCSerializedDataKey_AppVersion              = @"appVersion";
+NSString * const kAPCSerializedDataKey_FileInfoName            = @"filename";
+NSString * const kAPCSerializedDataKey_FileInfoTimeStamp       = @"timestamp";
+NSString * const kAPCSerializedDataKey_FileInfoContentType     = @"contentType";
+
+
+
 /**
  We use this regular-expression pattern to extract UUIDs
  from CoreData object IDs.


### PR DESCRIPTION
The point of this branch:  changed some +upload methods to require a "taskIdentifier" string, as requested by the server team, which shows up in the "item" field in the "info.json" file.  Also requires a "taskRunUuid," because elsewhere in the app, those two fields are tied together -- one says what we're uploading (like "monthly heart-health survey"), the other says which copy of that data is being uploaded.

Stuff I fixed as a side effect:
- enhanced the matching documentation
- fixed the MedicationTracker's Prescription class to use the new +upload method correctly
- changed literals to constants in the MedicationTracker's Prescription class

Testing procedures:

This was an incremental change to an existing "uploader" component.  The change involved adding two key-value pairs to a JSON manifest file in the upload. To test it, I wrote three methods that generated plain-text files and uploaded them, passing various combinations of following values for those two new fields:
- normal values, like "test_file.csv" and "happyFileName"
- nil
- UIUDs, both as NSUUID objects and as strings
- strings with "garbage" data, including randomly-typed characters, lots of spaces, backslash-n characters, tabs, and embedded quotation marks

...and verified that those strings ended up in the JSON file as intended -- either as the specified string or a JSON "null" value.

In addition, this change affected a component which uses the uploader: the "medication tracker." So after the change, I tested the medication tracker in the 3 situations which generate an upload:
- creating a prescription
- taking a pill for a prescription
- canceling the prescription

I ran those tests twice: once using the code from before the change, once using the code from after the change. Then I compared the "before" output for each situation to the "after" output for that same situation. Except for the two key-value pairs added as a result of this change, the output is identical, as it should be.
