### PR TITLE
[JIRA-2883] Keeping the elements of the items array in sync as the order is updated

### DIFF
--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Dashboard/APCDashboardEditViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Dashboard/APCDashboardEditViewController.m
@@ -102,7 +102,12 @@
     
     [self.rowItemsOrder removeObjectAtIndex:sourceIndexPath.row];
     [self.rowItemsOrder insertObject:rowTypeNumber atIndex:destinationIndexPath.row];
-
+    
+    // update the items array to reflect the updated item order.
+    APCTableViewDashboardItem *selectedItem = [self.items objectAtIndex:sourceIndexPath.row];
+    
+    [self.items removeObjectAtIndex:sourceIndexPath.row];
+    [self.items insertObject:selectedItem atIndex:destinationIndexPath.row];
 }
 
 - (UITableViewCellEditingStyle) tableView: (UITableView *) __unused tableView


### PR DESCRIPTION
There are two arrays that need to be tracked; one for the item order and the other for the items (cells) themselves. When rearranging the cells, the item order array is being updated, but the items array was not. This was causing issues on some devices where duplicate cells were being created and the order was not being reflected properly. [JIRA-2883]
