### PR TITLE
[APC-2930] Showing the 'EXAMPLE' watermark on Consent by default.

### DIFF
--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
@@ -81,6 +81,7 @@ FOUNDATION_EXPORT NSString *const APCHealthKitObserverQueryUpdateForSampleTypeNo
 FOUNDATION_EXPORT NSString *const kStudyIdentifierKey;
 FOUNDATION_EXPORT NSString *const kAppPrefixKey;
 FOUNDATION_EXPORT NSString *const kBridgeEnvironmentKey;
+FOUNDATION_EXPORT NSString *const kExampleConsentKey;
 FOUNDATION_EXPORT NSString *const kDatabaseNameKey;
 FOUNDATION_EXPORT NSString *const kTasksAndSchedulesJSONFileNameKey;
 FOUNDATION_EXPORT NSString *const kConsentSectionFileNameKey;

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
@@ -66,6 +66,7 @@ NSString *const APCHealthKitObserverQueryUpdateForSampleTypeNotification = @"APC
 NSString *const kStudyIdentifierKey                 = @"StudyIdentifierKey";
 NSString *const kAppPrefixKey                       = @"AppPrefixKey";
 NSString *const kBridgeEnvironmentKey               = @"BridgeEnvironmentKey";
+NSString *const kExampleConsentKey                  = @"ExampleConsentKey";
 NSString *const kDatabaseNameKey                    = @"DatabaseNameKey";
 NSString *const kTasksAndSchedulesJSONFileNameKey   = @"TasksAndSchedulesJSONFileNameKey";
 NSString *const kConsentSectionFileNameKey          = @"ConsentSectionFileNameKey";

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
@@ -68,7 +68,7 @@ extern NSString *const ParametersValueChangeNotification;
 
 @property (nonatomic) BOOL hideConsent;
 @property (nonatomic) BOOL bypassServer;
-@property (nonatomic) BOOL showExampleConsent;
+@property (nonatomic) BOOL hideExampleConsent;
 
 @end
 

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
@@ -68,6 +68,7 @@ extern NSString *const ParametersValueChangeNotification;
 
 @property (nonatomic) BOOL hideConsent;
 @property (nonatomic) BOOL bypassServer;
+@property (nonatomic) BOOL showExampleConsent;
 
 @end
 

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
@@ -374,6 +374,17 @@ NSString *const kBypassServerProperty                   = @"bypassServer";
     [[NSUserDefaults standardUserDefaults] setBool:bypassServer forKey:kBypassServerProperty];
 }
 
+- (BOOL)showExampleConsent
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kExampleConsentKey];
+}
+
+- (void)setShowExampleConsent:(BOOL)showExampleConsent
+{
+    [[NSUserDefaults standardUserDefaults] setBool:showExampleConsent forKey:kExampleConsentKey];
+}
+
+
 /*********************************************************************************/
 #pragma mark - Delegate Methods
 /*********************************************************************************/

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
@@ -374,14 +374,14 @@ NSString *const kBypassServerProperty                   = @"bypassServer";
     [[NSUserDefaults standardUserDefaults] setBool:bypassServer forKey:kBypassServerProperty];
 }
 
-- (BOOL)showExampleConsent
+- (BOOL)hideExampleConsent
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:kExampleConsentKey];
 }
 
-- (void)setShowExampleConsent:(BOOL)showExampleConsent
+- (void)setHideExampleConsent:(BOOL)hideExampleConsent
 {
-    [[NSUserDefaults standardUserDefaults] setBool:showExampleConsent forKey:kExampleConsentKey];
+    [[NSUserDefaults standardUserDefaults] setBool:hideExampleConsent forKey:kExampleConsentKey];
 }
 
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -1676,6 +1676,12 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     
     [consentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
     
+    NSUInteger subviewsCount = delegateConsentVC.view.subviews.count;
+    UILabel *watermarkLabel = [APCExampleLabel watermarkInRect:delegateConsentVC.view.bounds
+                                                    withCenter:delegateConsentVC.view.center];
+    
+    [delegateConsentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
+    
     [self presentViewController:consentVC animated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.h
+++ b/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.h
@@ -2,7 +2,7 @@
 //  APCExampleLabel.h
 //  APCAppCore
 //
-//  Copyright (c) 2015, Apple Inc. All rights reserved.
+// Copyright (c) 2015, Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
+++ b/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
@@ -42,7 +42,7 @@
     
     APCAppDelegate *appDelegate = (APCAppDelegate*)[UIApplication sharedApplication].delegate;
     
-    if (appDelegate.dataSubstrate.parameters.showExampleConsent) {
+    if (!appDelegate.dataSubstrate.parameters.hideExampleConsent) {
         CGRect screenSize = rect;
         
         double height = screenSize.size.height;

--- a/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
+++ b/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
@@ -32,29 +32,35 @@
 //
 
 #import "APCExampleLabel.h"
+#import "APCAppCore.h"
 
 @implementation APCExampleLabel
 
 + (UILabel *)watermarkInRect:(CGRect)rect withCenter:(CGPoint)center
 {
-    CGRect screenSize = rect;
-    
-    double height = screenSize.size.height;
-    double width  = screenSize.size.width;
-    double hypotenuse = hypotf(width, height);
-    double rotationAngle = asin(height/hypotenuse);
-    
     UILabel* watermarkLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-    watermarkLabel.text = NSLocalizedString(@"EXAMPLE", nil);
-    watermarkLabel.font = [UIFont systemFontOfSize:72.0];
-    watermarkLabel.textColor = [UIColor colorWithWhite:0 alpha:0.05];
-    watermarkLabel.textAlignment = NSTextAlignmentCenter;
-    [watermarkLabel sizeToFit];
     
-    watermarkLabel.center = center;
+    APCAppDelegate *appDelegate = (APCAppDelegate*)[UIApplication sharedApplication].delegate;
     
-    watermarkLabel.layer.affineTransform = CGAffineTransformMakeRotation(-rotationAngle);
-    
+    if (appDelegate.dataSubstrate.parameters.showExampleConsent) {
+        CGRect screenSize = rect;
+        
+        double height = screenSize.size.height;
+        double width  = screenSize.size.width;
+        double hypotenuse = hypotf(width, height);
+        double rotationAngle = asin(height/hypotenuse);
+        
+        watermarkLabel.text = NSLocalizedString(@"EXAMPLE", nil);
+        watermarkLabel.font = [UIFont systemFontOfSize:72.0];
+        watermarkLabel.textColor = [UIColor colorWithWhite:0 alpha:0.05];
+        watermarkLabel.textAlignment = NSTextAlignmentCenter;
+        [watermarkLabel sizeToFit];
+        
+        watermarkLabel.center = center;
+        
+        watermarkLabel.layer.affineTransform = CGAffineTransformMakeRotation(-rotationAngle);
+    }
+
     return watermarkLabel;
 }
 


### PR DESCRIPTION
The allows the watermark that is displayed across the Consent (from all its access points).
