### PR TITLE
Lessen AppCore dependency, remove double-define

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCDateRange.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCDateRange.m
@@ -32,7 +32,7 @@
 // 
  
 #import "APCDateRange.h"
-#import "APCAppCore.h"
+#import "NSDate+Helper.h"
 
 @implementation APCDateRange
 

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
@@ -32,8 +32,17 @@
 // 
  
 #import "APCTasksReminderManager.h"
-#import "APCAppCore.h"
+#import "APCAppDelegate.h"
+#import "APCScheduledTask+AddOn.h"
+#import "APCResult+AddOn.h"
+
 #import "APCConstants.h"
+#import "APCLog.h"
+#import "NSDate+Helper.h"
+#import "NSDictionary+APCAdditions.h"
+#import "NSManagedObject+APCHelper.h"
+
+#import <UIKit/UIKit.h>
 
 NSString * const kTaskReminderUserInfo = @"CurrentTaskReminder";
 NSString * const kSubtaskReminderUserInfo = @"CurrentSubtaskReminder";
@@ -160,7 +169,8 @@ NSString * const kTaskReminderDelayMessage = @"Remind me in 1 hour";
         {
             UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeAlert
                                                                                                  |UIUserNotificationTypeBadge
-                                                                                                 |UIUserNotificationTypeSound) categories:[APCTasksReminderManager taskReminderCategories]];
+                                                                                                 |UIUserNotificationTypeSound)
+																					 categories:[APCTasksReminderManager taskReminderCategories]];
             
             [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
             [[NSUserDefaults standardUserDefaults]synchronize];

--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.h
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.h
@@ -32,7 +32,6 @@
 // 
  
 #import <Foundation/Foundation.h>
-#import "APCAppCore.h"
 #import "APCConstants.h"
 
 typedef void(^APCPermissionsBlock)(BOOL granted, NSError *error);

--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
@@ -32,7 +32,10 @@
 // 
  
 #import "APCPermissionsManager.h"
+#import "APCUserInfoConstants.h"
+#import "APCTasksReminderManager.h"
 
+#import <UIKit/UIKit.h>
 #import <CoreMotion/CoreMotion.h>
 #import <CoreLocation/CoreLocation.h>
 #import <HealthKit/HealthKit.h>

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -1177,6 +1177,9 @@ static NSUInteger const kIndexOfProfileTab = 3;
 
 - (void)passcodeViewControllerDidSucceed:(APCPasscodeViewController *) __unused viewController
 {
+	[[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:kLastUsedTimeKey];
+	[[NSUserDefaults standardUserDefaults] synchronize];
+	
     self.isPasscodeShowing = NO;
 }
 

--- a/APCAppCore/APCAppCore/Startup/APCTabBarViewController.m
+++ b/APCAppCore/APCAppCore/Startup/APCTabBarViewController.m
@@ -33,9 +33,8 @@
  
 
 #import "APCTabBarViewController.h"
-#import "APCAppCore.h"
+#import "APCPasscodeViewController.h"
 
-static NSString *const kLastUsedTimeKey = @"APHLastUsedTime";
 
 @interface APCTabBarViewController () <APCPasscodeViewControllerDelegate>
 @property (nonatomic) BOOL isPasscodeShowing;
@@ -54,7 +53,7 @@ static NSString *const kLastUsedTimeKey = @"APHLastUsedTime";
 - (void)showPasscode
 {
     if (!self.isPasscodeShowing) {
-        APCPasscodeViewController *passcodeViewController = [[UIStoryboard storyboardWithName:@"APCPasscode" bundle:[NSBundle appleCoreBundle]] instantiateInitialViewController];
+        APCPasscodeViewController *passcodeViewController = [[UIStoryboard storyboardWithName:@"APCPasscode" bundle:[NSBundle bundleForClass:[self class]]] instantiateInitialViewController];
         passcodeViewController.delegate = self;
         UIViewController * presentVC = self.presentedViewController ? self.presentedViewController : self;
         [presentVC presentViewController:passcodeViewController animated:YES completion:nil];
@@ -67,8 +66,6 @@ static NSString *const kLastUsedTimeKey = @"APHLastUsedTime";
     self.isPasscodeShowing = NO;
     self.showPasscodeScreen = NO;
     [viewController dismissViewControllerAnimated:YES completion:nil];
-    [[NSUserDefaults standardUserDefaults] setObject: [NSDate date] forKey:kLastUsedTimeKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
     if ([self.passcodeDelegate respondsToSelector:@selector(passcodeViewControllerDidSucceed:)]) {
         [self.passcodeDelegate passcodeViewControllerDidSucceed: viewController];
     }

--- a/APCAppCore/APCAppCore/UI/ViewControllers/APCPasscodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/ViewControllers/APCPasscodeViewController.m
@@ -40,7 +40,7 @@
 #import "APCKeychainStore.h"
 #import "APCUserInfoConstants.h"
 #import "UIImage+APCHelper.h"
-#import "APCAppCore.h"
+#import "APCLog.h"
 
 @interface APCPasscodeViewController ()<APCPasscodeViewDelegate>
 
@@ -84,7 +84,6 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-
     APCLogViewControllerAppeared();
 }
 


### PR DESCRIPTION
Removes some `#import "APCAppCore.h"` and replaces them with the individual imports needed by the class.

Also removes the `kLastUsedTimeKey` double-define and moves the one last-used-date capture into AppDelegate.
