### PR TITLE
Updating observer queries to use anchored query for collecting HealthKit data

### DIFF
--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
@@ -81,6 +81,7 @@ FOUNDATION_EXPORT NSString *const APCHealthKitObserverQueryUpdateForSampleTypeNo
 FOUNDATION_EXPORT NSString *const kStudyIdentifierKey;
 FOUNDATION_EXPORT NSString *const kAppPrefixKey;
 FOUNDATION_EXPORT NSString *const kBridgeEnvironmentKey;
+FOUNDATION_EXPORT NSString *const kExampleConsentKey;
 FOUNDATION_EXPORT NSString *const kDatabaseNameKey;
 FOUNDATION_EXPORT NSString *const kTasksAndSchedulesJSONFileNameKey;
 FOUNDATION_EXPORT NSString *const kConsentSectionFileNameKey;

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
@@ -66,6 +66,7 @@ NSString *const APCHealthKitObserverQueryUpdateForSampleTypeNotification = @"APC
 NSString *const kStudyIdentifierKey                 = @"StudyIdentifierKey";
 NSString *const kAppPrefixKey                       = @"AppPrefixKey";
 NSString *const kBridgeEnvironmentKey               = @"BridgeEnvironmentKey";
+NSString *const kExampleConsentKey                  = @"ExampleConsentKey";
 NSString *const kDatabaseNameKey                    = @"DatabaseNameKey";
 NSString *const kTasksAndSchedulesJSONFileNameKey   = @"TasksAndSchedulesJSONFileNameKey";
 NSString *const kConsentSectionFileNameKey          = @"ConsentSectionFileNameKey";

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
@@ -68,7 +68,7 @@ extern NSString *const ParametersValueChangeNotification;
 
 @property (nonatomic) BOOL hideConsent;
 @property (nonatomic) BOOL bypassServer;
-@property (nonatomic) BOOL showExampleConsent;
+@property (nonatomic) BOOL hideExampleConsent;
 
 @end
 

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.h
@@ -68,6 +68,7 @@ extern NSString *const ParametersValueChangeNotification;
 
 @property (nonatomic) BOOL hideConsent;
 @property (nonatomic) BOOL bypassServer;
+@property (nonatomic) BOOL showExampleConsent;
 
 @end
 

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
@@ -374,6 +374,17 @@ NSString *const kBypassServerProperty                   = @"bypassServer";
     [[NSUserDefaults standardUserDefaults] setBool:bypassServer forKey:kBypassServerProperty];
 }
 
+- (BOOL)showExampleConsent
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kExampleConsentKey];
+}
+
+- (void)setShowExampleConsent:(BOOL)showExampleConsent
+{
+    [[NSUserDefaults standardUserDefaults] setBool:showExampleConsent forKey:kExampleConsentKey];
+}
+
+
 /*********************************************************************************/
 #pragma mark - Delegate Methods
 /*********************************************************************************/

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
@@ -374,14 +374,14 @@ NSString *const kBypassServerProperty                   = @"bypassServer";
     [[NSUserDefaults standardUserDefaults] setBool:bypassServer forKey:kBypassServerProperty];
 }
 
-- (BOOL)showExampleConsent
+- (BOOL)hideExampleConsent
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:kExampleConsentKey];
 }
 
-- (void)setShowExampleConsent:(BOOL)showExampleConsent
+- (void)setHideExampleConsent:(BOOL)hideExampleConsent
 {
-    [[NSUserDefaults standardUserDefaults] setBool:showExampleConsent forKey:kExampleConsentKey];
+    [[NSUserDefaults standardUserDefaults] setBool:hideExampleConsent forKey:kExampleConsentKey];
 }
 
 

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
@@ -89,6 +89,7 @@ extern NSUInteger   const kTheEntireDataModelOfTheApp;
 - (void) setUpInitializationOptions;
 - (void) setUpAppAppearance;
 - (void) registerCatastrophicStartupError: (NSError *) error;
+- (void) configureObserverQueries;
 
 //For User in Subclasses
 - (void) signedInNotification:(NSNotification *)notification;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -607,6 +607,12 @@ static NSUInteger const kIndexOfProfileTab = 3;
                 sampleType = [HKObjectType quantityTypeForIdentifier:dataType];
             }
             
+            if (![[NSUserDefaults standardUserDefaults] integerForKey:sampleType.identifier]) {
+                // Initialize the anchor to 0 that will be later used
+                // and updated by the anchored query.
+                [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:sampleType.identifier];
+            }
+            
             [self observerQueryForSampleType:sampleType
                               withCompletion:nil];
         }

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -884,7 +884,7 @@ static NSUInteger const kIndexOfProfileTab = 3;
                 HKCategorySample *catSample = (HKCategorySample *)quantitySample;
                 healthKitType = catSample.categoryType.identifier;
                 
-                if (healthKitType isEqualToString:HKCategoryTypeIdentifierSleepAnalysis) {
+                if ([healthKitType isEqualToString:HKCategoryTypeIdentifierSleepAnalysis]) {
                     quantityValue = [NSString stringWithFormat:@"%ld", (long)catSample.value];
                     
                     // Get the difference in seconds between the start and end date for the sample

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -582,39 +582,42 @@ static NSUInteger const kIndexOfProfileTab = 3;
   */
 - (void)configureObserverQueries
 {
-    NSArray *dataTypesWithReadPermission = self.initializationOptions[kHKReadPermissionsKey];
-    
-    if (dataTypesWithReadPermission) {
+    if (self.dataSubstrate.currentUser.consented) {
         
-        if (!self.healthKitCollectorQueue) {
-            self.healthKitCollectorQueue = [NSOperationQueue sequentialOperationQueueWithName:@"HealthKit Data Collector"];
-        }
+        NSArray *dataTypesWithReadPermission = self.initializationOptions[kHKReadPermissionsKey];
         
-        if (!self.healthKitCollector) {
-            self.healthKitCollector = [[APCHealthKitDataCollector alloc] initWithIdentifier:@"HealthKitDataCollector"];
-            [self.passiveDataCollector addTracker:self.healthKitCollector];
-            [self.healthKitCollector startTracking];
-        }
-        
-        for (id dataType in dataTypesWithReadPermission) {
+        if (dataTypesWithReadPermission) {
             
-            HKSampleType *sampleType = nil;
-            
-            if ([dataType isKindOfClass:[NSDictionary class]]) {
-                NSDictionary *categoryType = (NSDictionary *)dataType;
-                sampleType = [HKObjectType categoryTypeForIdentifier:categoryType[kHKCategoryTypeKey]];
-            } else {
-                sampleType = [HKObjectType quantityTypeForIdentifier:dataType];
+            if (!self.healthKitCollectorQueue) {
+                self.healthKitCollectorQueue = [NSOperationQueue sequentialOperationQueueWithName:@"HealthKit Data Collector"];
             }
             
-            if (![[NSUserDefaults standardUserDefaults] integerForKey:sampleType.identifier]) {
-                // Initialize the anchor to 0 that will be later used
-                // and updated by the anchored query.
-                [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:sampleType.identifier];
+            if (!self.healthKitCollector) {
+                self.healthKitCollector = [[APCHealthKitDataCollector alloc] initWithIdentifier:@"HealthKitDataCollector"];
+                [self.passiveDataCollector addTracker:self.healthKitCollector];
+                [self.healthKitCollector startTracking];
             }
             
-            [self observerQueryForSampleType:sampleType
-                              withCompletion:nil];
+            for (id dataType in dataTypesWithReadPermission) {
+                
+                HKSampleType *sampleType = nil;
+                
+                if ([dataType isKindOfClass:[NSDictionary class]]) {
+                    NSDictionary *categoryType = (NSDictionary *)dataType;
+                    sampleType = [HKObjectType categoryTypeForIdentifier:categoryType[kHKCategoryTypeKey]];
+                } else {
+                    sampleType = [HKObjectType quantityTypeForIdentifier:dataType];
+                }
+                
+                if (![[NSUserDefaults standardUserDefaults] integerForKey:sampleType.identifier]) {
+                    // Initialize the anchor to 0 that will be later used
+                    // and updated by the anchored query.
+                    [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:sampleType.identifier];
+                }
+                
+                [self observerQueryForSampleType:sampleType
+                                  withCompletion:nil];
+            }
         }
     }
 }
@@ -710,11 +713,19 @@ static NSUInteger const kIndexOfProfileTab = 3;
                     completionHandler();
                 } else {
                     NSUInteger anchorForSampleType = [[NSUserDefaults standardUserDefaults] integerForKey:sampleType.identifier];
+                    NSPredicate *predicate = nil;
+                    NSDate *consentDate = self.dataSubstrate.currentUser.consentSignatureDate;
+                    
+                    if (anchorForSampleType == 0) {
+                        predicate = [NSPredicate predicateWithFormat:@"%K >= %@",
+                                     HKPredicateKeyPathStartDate,
+                                     [consentDate startOfDay]];
+                    }
                     
                     APCLogDebug(@"Anchor: %lu (%@)", anchorForSampleType, sampleType.identifier);
                     
                     HKAnchoredObjectQuery *anchoredQuery = [[HKAnchoredObjectQuery alloc] initWithType:sampleType
-                                                                                             predicate:nil
+                                                                                             predicate:predicate
                                                                                                 anchor:anchorForSampleType
                                                                                                  limit:HKObjectQueryNoLimit
                                                                                      completionHandler:^(HKAnchoredObjectQuery * __unused query,

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -883,17 +883,20 @@ static NSUInteger const kIndexOfProfileTab = 3;
             if ([quantitySample isKindOfClass:[HKCategorySample class]]) {
                 HKCategorySample *catSample = (HKCategorySample *)quantitySample;
                 healthKitType = catSample.categoryType.identifier;
-                quantityValue = [NSString stringWithFormat:@"%ld", (long)catSample.value];
                 
-                // Get the difference in seconds between the start and end date for the sample
-                NSDateComponents *secondsSpentInBedOrAsleep = [[NSCalendar currentCalendar] components:NSCalendarUnitSecond
-                                                                                              fromDate:catSample.startDate
-                                                                                                toDate:catSample.endDate
-                                                                                               options:NSCalendarWrapComponents];
-                if (catSample.value == HKCategoryValueSleepAnalysisInBed) {
-                    quantityValue = [NSString stringWithFormat:@"%ld,seconds in bed", (long)secondsSpentInBedOrAsleep.second];
-                } else if (catSample.value == HKCategoryValueSleepAnalysisAsleep) {
-                    quantityValue = [NSString stringWithFormat:@"%ld,seconds asleep", (long)secondsSpentInBedOrAsleep.second];
+                if (healthKitType isEqualToString:HKCategoryTypeIdentifierSleepAnalysis) {
+                    quantityValue = [NSString stringWithFormat:@"%ld", (long)catSample.value];
+                    
+                    // Get the difference in seconds between the start and end date for the sample
+                    NSDateComponents *secondsSpentInBedOrAsleep = [[NSCalendar currentCalendar] components:NSCalendarUnitSecond
+                                                                                                  fromDate:catSample.startDate
+                                                                                                    toDate:catSample.endDate
+                                                                                                   options:NSCalendarWrapComponents];
+                    if (catSample.value == HKCategoryValueSleepAnalysisInBed) {
+                        quantityValue = [NSString stringWithFormat:@"%ld,seconds in bed", (long)secondsSpentInBedOrAsleep.second];
+                    } else if (catSample.value == HKCategoryValueSleepAnalysisAsleep) {
+                        quantityValue = [NSString stringWithFormat:@"%ld,seconds asleep", (long)secondsSpentInBedOrAsleep.second];
+                    }
                 }
             } else {
                 HKQuantitySample *qtySample = (HKQuantitySample *)quantitySample;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -879,6 +879,8 @@ static NSUInteger const kIndexOfProfileTab = 3;
             NSString *healthKitType = nil;
             NSString *quantityValue = nil;
             NSString *dateTimeStamp = [quantitySample.startDate toStringInISO8601Format];
+            NSString *sourceBundleIdentifier = quantitySample.source.bundleIdentifier;
+            NSString *sourceName = quantitySample.source.name;
             
             if ([quantitySample isKindOfClass:[HKCategorySample class]]) {
                 HKCategorySample *catSample = (HKCategorySample *)quantitySample;
@@ -906,7 +908,9 @@ static NSUInteger const kIndexOfProfileTab = 3;
                 quantityValue = [quantityValue stringByReplacingOccurrencesOfString:@" " withString:@","];
             }
             
-            NSString *stringToWrite = [NSString stringWithFormat:@"%@,%@,%@\n", dateTimeStamp, healthKitType, quantityValue];
+            NSString *stringToWrite = [NSString stringWithFormat:@"%@,%@,%@,%@,%@\n",
+                                       dateTimeStamp, sourceBundleIdentifier, sourceName,
+                                       healthKitType, quantityValue];
             
             [APCPassiveDataCollector createOrAppendString:stringToWrite
                                                    toFile:filename];

--- a/APCAppCore/APCAppCore/Startup/APCHealthKitDataCollector.m
+++ b/APCAppCore/APCAppCore/Startup/APCHealthKitDataCollector.m
@@ -59,7 +59,7 @@ static NSString *const kHealthKitDataCollectorFilename = @"data.csv";
 
 - (NSArray *)columnNames
 {
-    return @[@"datetime,type,value"];
+    return @[@"datetime,sourceBundleIdentifier,sourceName,type,value,unit"];
 }
 
 @end

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCAllSetContentViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCAllSetContentViewController.m
@@ -64,6 +64,11 @@ typedef NS_ENUM(NSUInteger, APCAllSetRows)
     
     [self configureTextBlocks];
     
+    self.demographicUploader = [[APCDemographicUploader alloc] init];
+    [self.demographicUploader uploadNonIdentifiableDemographicData];
+    
+    [(APCAppDelegate *)[UIApplication sharedApplication].delegate configureObserverQueries];
+    
     [self.tableView reloadData];
 }
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -1676,6 +1676,12 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     
     [consentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
     
+    NSUInteger subviewsCount = delegateConsentVC.view.subviews.count;
+    UILabel *watermarkLabel = [APCExampleLabel watermarkInRect:delegateConsentVC.view.bounds
+                                                    withCenter:delegateConsentVC.view.center];
+    
+    [delegateConsentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
+    
     [self presentViewController:consentVC animated:YES completion:nil];
 }
 

--- a/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.h
+++ b/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.h
@@ -2,7 +2,7 @@
 //  APCExampleLabel.h
 //  APCAppCore
 //
-//  Copyright (c) 2015, Apple Inc. All rights reserved.
+// Copyright (c) 2015, Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
+++ b/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
@@ -42,7 +42,7 @@
     
     APCAppDelegate *appDelegate = (APCAppDelegate*)[UIApplication sharedApplication].delegate;
     
-    if (appDelegate.dataSubstrate.parameters.showExampleConsent) {
+    if (!appDelegate.dataSubstrate.parameters.hideExampleConsent) {
         CGRect screenSize = rect;
         
         double height = screenSize.size.height;

--- a/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
+++ b/APCAppCore/APCAppCore/UI/Views/APCExampleLabel.m
@@ -32,29 +32,35 @@
 //
 
 #import "APCExampleLabel.h"
+#import "APCAppCore.h"
 
 @implementation APCExampleLabel
 
 + (UILabel *)watermarkInRect:(CGRect)rect withCenter:(CGPoint)center
 {
-    CGRect screenSize = rect;
-    
-    double height = screenSize.size.height;
-    double width  = screenSize.size.width;
-    double hypotenuse = hypotf(width, height);
-    double rotationAngle = asin(height/hypotenuse);
-    
     UILabel* watermarkLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-    watermarkLabel.text = NSLocalizedString(@"EXAMPLE", nil);
-    watermarkLabel.font = [UIFont systemFontOfSize:72.0];
-    watermarkLabel.textColor = [UIColor colorWithWhite:0 alpha:0.05];
-    watermarkLabel.textAlignment = NSTextAlignmentCenter;
-    [watermarkLabel sizeToFit];
     
-    watermarkLabel.center = center;
+    APCAppDelegate *appDelegate = (APCAppDelegate*)[UIApplication sharedApplication].delegate;
     
-    watermarkLabel.layer.affineTransform = CGAffineTransformMakeRotation(-rotationAngle);
-    
+    if (appDelegate.dataSubstrate.parameters.showExampleConsent) {
+        CGRect screenSize = rect;
+        
+        double height = screenSize.size.height;
+        double width  = screenSize.size.width;
+        double hypotenuse = hypotf(width, height);
+        double rotationAngle = asin(height/hypotenuse);
+        
+        watermarkLabel.text = NSLocalizedString(@"EXAMPLE", nil);
+        watermarkLabel.font = [UIFont systemFontOfSize:72.0];
+        watermarkLabel.textColor = [UIColor colorWithWhite:0 alpha:0.05];
+        watermarkLabel.textAlignment = NSTextAlignmentCenter;
+        [watermarkLabel sizeToFit];
+        
+        watermarkLabel.center = center;
+        
+        watermarkLabel.layer.affineTransform = CGAffineTransformMakeRotation(-rotationAngle);
+    }
+
     return watermarkLabel;
 }
 


### PR DESCRIPTION
We are setting up observer queries for each of the HealthKit sample types that the user has given us permission to read.
