### PR TITLE
Import additional headers to allow successful compilation.

### DIFF
--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
@@ -34,6 +34,7 @@
 #import "APCPermissionsManager.h"
 #import "APCUserInfoConstants.h"
 #import "APCTasksReminderManager.h"
+#import "APCAppDelegate.h"
 
 #import <UIKit/UIKit.h>
 #import <CoreMotion/CoreMotion.h>

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
@@ -34,6 +34,19 @@
 #import "APCSignUpGeneralInfoViewController.h"
 #import "APCPermissionButton.h"
 #import "APCPermissionsManager.h"
+#import "APCTermsAndConditionsViewController.h"
+#import "APCOnboarding.h"
+#import "APCAppDelegate.h"
+#import "UIColor+APCAppearance.h"
+#import "NSDate+Helper.h"
+#import "NSString+Helper.h"
+#import "UIFont+APCAppearance.h"
+#import "UIAlertController+Helper.h"
+#import "NSBundle+Helper.h"
+#import "APCSpinnerViewController.h"
+#import "APCUser+Bridge.h"
+#import "APCLog.h"
+#import "NSError+APCAdditions.h"
 
 static NSString *kInternetNotAvailableErrorMessage1 = @"Internet Not Connected";
 static NSString *kInternetNotAvailableErrorMessage2 = @"BackendServer Not Reachable";

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -1676,12 +1676,6 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     
     [consentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
     
-    NSUInteger subviewsCount = delegateConsentVC.view.subviews.count;
-    UILabel *watermarkLabel = [APCExampleLabel watermarkInRect:delegateConsentVC.view.bounds
-                                                    withCenter:delegateConsentVC.view.center];
-    
-    [delegateConsentVC.view insertSubview:watermarkLabel atIndex:subviewsCount];
-    
     [self presentViewController:consentVC animated:YES completion:nil];
 }
 


### PR DESCRIPTION
Correction for a bad merge and import necessary headers in order to allow successful compilation of `APCPermissionsManager` and `APCSignUpGeneralInfoViewController`.
