### PR TITLE
Split NSError category into two

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -322,6 +322,8 @@
 		CFFDEDFA1A95734000B25581 /* APCSetupTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = CFFDEDC01A95734000B25581 /* APCSetupTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CFFDEDFB1A95734000B25581 /* APCSetupTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = CFFDEDC11A95734000B25581 /* APCSetupTableViewCell.m */; };
 		CFFDEDFC1A95734000B25581 /* APCSetupTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CFFDEDC21A95734000B25581 /* APCSetupTableViewCell.xib */; };
+		EE4B95251AF82BA6000097C7 /* NSError+Bridge.h in Headers */ = {isa = PBXBuildFile; fileRef = EE4B95231AF82BA6000097C7 /* NSError+Bridge.h */; };
+		EE4B95261AF82BA6000097C7 /* NSError+Bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = EE4B95241AF82BA6000097C7 /* NSError+Bridge.m */; };
 		F50738C01A682E12004CF100 /* APCDateRange.h in Headers */ = {isa = PBXBuildFile; fileRef = F50738BE1A682E12004CF100 /* APCDateRange.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F50738C11A682E12004CF100 /* APCDateRange.m in Sources */ = {isa = PBXBuildFile; fileRef = F50738BF1A682E12004CF100 /* APCDateRange.m */; };
 		F5306CCD1A8BE7F600732E60 /* ORKQuestionResult+APCHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F5306CCB1A8BE7F600732E60 /* ORKQuestionResult+APCHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1005,6 +1007,8 @@
 		CFFDEDC01A95734000B25581 /* APCSetupTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCSetupTableViewCell.h; sourceTree = "<group>"; };
 		CFFDEDC11A95734000B25581 /* APCSetupTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCSetupTableViewCell.m; sourceTree = "<group>"; };
 		CFFDEDC21A95734000B25581 /* APCSetupTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = APCSetupTableViewCell.xib; sourceTree = "<group>"; };
+		EE4B95231AF82BA6000097C7 /* NSError+Bridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+Bridge.h"; sourceTree = "<group>"; };
+		EE4B95241AF82BA6000097C7 /* NSError+Bridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+Bridge.m"; sourceTree = "<group>"; };
 		F50738BE1A682E12004CF100 /* APCDateRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCDateRange.h; sourceTree = "<group>"; };
 		F50738BF1A682E12004CF100 /* APCDateRange.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCDateRange.m; sourceTree = "<group>"; };
 		F5179B2919D09128001DCCB7 /* APCAppCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = APCAppCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2189,6 +2193,8 @@
 				F5B9474D1A73272C0034C522 /* NSDictionary+APCAdditions.m */,
 				F5B9474E1A73272C0034C522 /* NSError+APCAdditions.h */,
 				F5B9474F1A73272C0034C522 /* NSError+APCAdditions.m */,
+				EE4B95231AF82BA6000097C7 /* NSError+Bridge.h */,
+				EE4B95241AF82BA6000097C7 /* NSError+Bridge.m */,
 				F5B947501A73272C0034C522 /* NSManagedObject+APCHelper.h */,
 				F5B947511A73272C0034C522 /* NSManagedObject+APCHelper.m */,
 				F5B947521A73272C0034C522 /* NSObject+Helper.h */,
@@ -2983,6 +2989,7 @@
 				CF7945861AA7AEC70019160F /* APCFrequencyEverydayTableViewCell.h in Headers */,
 				F5F12A7B1A2F78490015982C /* APCCircleView.h in Headers */,
 				F5F129FE1A2F78490015982C /* APCSchedule.h in Headers */,
+				EE4B95251AF82BA6000097C7 /* NSError+Bridge.h in Headers */,
 				0875C3D81A797A7B00CE50FB /* APCButton.h in Headers */,
 				5B9B36A71A95D9C900389F42 /* APCActivitiesBasicTableViewCell.h in Headers */,
 				3650C65B1AA29BB50075C935 /* APCCatastrophicErrorViewController.h in Headers */,
@@ -3466,6 +3473,7 @@
 				3627D34D1A9A7517006B02E8 /* APCMedTrackerPossibleDosage.m in Sources */,
 				5B9B36A41A95D9B500389F42 /* APCActivitiesTintedTableViewCell.m in Sources */,
 				F5F12AC61A2F78490015982C /* APCLearnStudyDetailsViewController.m in Sources */,
+				EE4B95261AF82BA6000097C7 /* NSError+Bridge.m in Sources */,
 				F5B947EA1A73272C0034C522 /* APCTasksReminderManager.m in Sources */,
 				F5B948051A73272C0034C522 /* APCPointSelector.m in Sources */,
 				F5F12AAD1A2F78490015982C /* APCSignUpGeneralInfoViewController.m in Sources */,

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.h
@@ -33,16 +33,16 @@
  
 #import <Foundation/Foundation.h>
 
-FOUNDATION_EXPORT NSString * const kServerBusy;
-FOUNDATION_EXPORT NSString * const kUnexpectConditionMessage;
-FOUNDATION_EXPORT NSString * const kNotConnectedMessage;
-FOUNDATION_EXPORT NSString * const kServerMaintanenceMessage;
-FOUNDATION_EXPORT NSString * const kAccountAlreadyExists;
-FOUNDATION_EXPORT NSString * const kAccountDoesNotExists;
-FOUNDATION_EXPORT NSString * const kBadEmailAddress;
-FOUNDATION_EXPORT NSString * const kBadPasswordAddress;
-FOUNDATION_EXPORT NSString * const kNotReachableMessage;
-FOUNDATION_EXPORT NSString * const kInvalidEmailAddressOrPassword;
+FOUNDATION_EXPORT NSString * const kAPCServerBusyErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCUnexpectedConditionErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCNotConnectedErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCServerUnderMaintanenceErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCAccountAlreadyExistsErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCAccountDoesNotExistErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCBadEmailAddressErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCBadPasswordErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCNotReachableErrorMessage;
+FOUNDATION_EXPORT NSString * const kAPCInvalidEmailAddressOrPasswordErrorMessage;
 
 @interface NSError (APCAdditions)
 

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.h
@@ -33,6 +33,17 @@
  
 #import <Foundation/Foundation.h>
 
+FOUNDATION_EXPORT NSString * const kServerBusy;
+FOUNDATION_EXPORT NSString * const kUnexpectConditionMessage;
+FOUNDATION_EXPORT NSString * const kNotConnectedMessage;
+FOUNDATION_EXPORT NSString * const kServerMaintanenceMessage;
+FOUNDATION_EXPORT NSString * const kAccountAlreadyExists;
+FOUNDATION_EXPORT NSString * const kAccountDoesNotExists;
+FOUNDATION_EXPORT NSString * const kBadEmailAddress;
+FOUNDATION_EXPORT NSString * const kBadPasswordAddress;
+FOUNDATION_EXPORT NSString * const kNotReachableMessage;
+FOUNDATION_EXPORT NSString * const kInvalidEmailAddressOrPassword;
+
 @interface NSError (APCAdditions)
 
 /*********************************************************************************/

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.m
@@ -31,23 +31,19 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 // 
  
-#import "APCAppCore.h"
+#import "NSError+APCAdditions.h"
+#import "APCLog.h"
 
-static NSString*    kServerBusy                     = @"Thank you for your interest in this study. We are working hard to process the large volume of interest, and should be back up momentarily. Please try again soon.";
-static NSString*    kUnexpectConditionMessage       = @"An unexpected network condition has occurred. Please try again soon.";
-static NSString*    kNotConnectedMessage            = @"You are currently not connected to the Internet. Please try again when you are connected to a network.";
-static NSString*    kServerMaintanenceMessage       = @"The study server is currently undergoing maintanence. Please try again soon.";
-static NSString*    kAccountAlreadyExists           = @"An account has already been created for this email address. Please use a different email address, or sign in using the \"already participating\" link at the bottom of the Welcome page.";
-static NSString*    kAccountDoesNotExists           = @"There is no account registered for this email address.";
-static NSString*    kBadEmailAddress                = @"The email address submitted is not a valid email address. Please correct the email address and try again.";
-static NSString*    kBadPasswordAddress             = @"The password you have entered is not a valid password.  Please try again.";
-static NSString*    kNotReachableMessage            = @"We are currently not able to reach the study server. Please retry in a few moments.";
-static NSString*    kInvalidEmailAddressOrPassword  = @"Entered email address or password is not valid. Please correct the email address or password and try again.";
-static NSString*    kSageMessageKey                 = @"message";
-static NSString*    kSageErrorsKey                  = @"errors";
-static NSString*    kSageErrorPasswordKey           = @"password";
-static NSString*    kSageErrorEmailKey              = @"email";
-static NSString*    kSageInvalidUsernameOrPassword  = @"Invalid username or password.";
+NSString * const kServerBusy                     = @"Thank you for your interest in this study. We are working hard to process the large volume of interest, and should be back up momentarily. Please try again soon.";
+NSString * const kUnexpectConditionMessage       = @"An unexpected network condition has occurred. Please try again soon.";
+NSString * const kNotConnectedMessage            = @"You are currently not connected to the Internet. Please try again when you are connected to a network.";
+NSString * const kServerMaintanenceMessage       = @"The study server is currently undergoing maintanence. Please try again soon.";
+NSString * const kAccountAlreadyExists           = @"An account has already been created for this email address. Please use a different email address, or sign in using the \"already participating\" link at the bottom of the Welcome page.";
+NSString * const kAccountDoesNotExists           = @"There is no account registered for this email address.";
+NSString * const kBadEmailAddress                = @"The email address submitted is not a valid email address. Please correct the email address and try again.";
+NSString * const kBadPasswordAddress             = @"The password you have entered is not a valid password.  Please try again.";
+NSString * const kNotReachableMessage            = @"We are currently not able to reach the study server. Please retry in a few moments.";
+NSString * const kInvalidEmailAddressOrPassword  = @"Entered email address or password is not valid. Please correct the email address or password and try again.";
 
 static NSString * const oneTab = @"    ";
 
@@ -62,11 +58,6 @@ static NSString * const oneTab = @"    ";
     {
         return NSLocalizedString(@"An unknown error occurred", nil);
     }
-    else
-    {
-        return message;
-    }
-    
     return message;
 }
 
@@ -82,97 +73,23 @@ static NSString * const oneTab = @"    ";
 }
 
 
-- (NSString*)bridgeErrorMessage
+- (NSString *)networkErrorMessage
 {
-    NSString*   message;
-    id          code = self.userInfo[SBB_ORIGINAL_ERROR_KEY];
+    NSString *message;
     
-    if ([code isKindOfClass:[NSError class]])
-    {
-        NSError*    e = (NSError*)code;
-        
-        if (e.code == kCFURLErrorNotConnectedToInternet)
-        {
-            message = NSLocalizedString(kNotConnectedMessage, nil);
-        }
-        else
-        {
-            APCLogError(@"Network error: %@", code);
-        }
-    }
-    else if (self.code == 400)
-    {
-        // There are several messages that need to be displayed within the 400
-        // Extract the internal message then act appropriately.
-        NSDictionary * errors = [code valueForKey: kSageErrorsKey];
-        if([errors valueForKey: kSageErrorEmailKey])
-        {
-            message = NSLocalizedString(kBadEmailAddress, nil);
-        }
-        else if([errors valueForKey: kSageErrorPasswordKey])
-        {
-            message = NSLocalizedString(kBadPasswordAddress, nil);
-        } else
-        {
-            message = NSLocalizedString(kInvalidEmailAddressOrPassword, nil);
-        }
-        
-    }
-    else if (self.code == 409)
-    {
+    if (self.code == 409) {
         message = NSLocalizedString(kAccountAlreadyExists, nil);
     }
-    else if (self.code == 404)
-    {
+    else if (self.code == 404) {
         message = NSLocalizedString(kAccountDoesNotExists, nil);
     }
-    else if ([code isEqual:@(503)] || self.code == 503)
-    {
+    else if (self.code >= 500 && self.code < 600) {
         message = NSLocalizedString(kServerBusy, nil);
     }
-    else if ([code  isEqual: @(kSBBInternetNotConnected)])
-    {
+    else if (self.code == kCFURLErrorDNSLookupFailed || self.code == kCFURLErrorInternationalRoamingOff) {
         message = NSLocalizedString(kNotConnectedMessage, nil);
     }
-    else if ([code isEqual:@(kSBBServerNotReachable)])
-    {
-        message = NSLocalizedString(kNotReachableMessage, nil);
-    }
-    else if ([code isEqual:@(kSBBServerUnderMaintenance)])
-    {
-        message = NSLocalizedString(kServerMaintanenceMessage, nil);
-    }
-    else
-    {
-        message = NSLocalizedString(kUnexpectConditionMessage, nil);
-    }
-
-    return message;
-}
-
-
-- (NSString*)networkErrorMessage
-{
-    NSString*   message;
-    
-    if (self.code == 409)
-    {
-        message = NSLocalizedString(kAccountAlreadyExists, nil);
-    }
-    else if (self.code == 404)
-    {
-        message = NSLocalizedString(kAccountDoesNotExists, nil);
-    }
-    else if (self.code >= 500 && self.code < 600)
-    {
-        message = NSLocalizedString(kServerBusy, nil);
-    }
-    else if (self.code == kCFURLErrorDNSLookupFailed || self.code == kCFURLErrorInternationalRoamingOff)
-    {
-        message = NSLocalizedString(kNotConnectedMessage, nil);
-    }
-    else
-    {
+    else {
         message = NSLocalizedString(kUnexpectConditionMessage, nil);
     }
     
@@ -180,19 +97,20 @@ static NSString * const oneTab = @"    ";
 }
 
 
-- (NSString*)message
+- (NSString *)message
 {
-    NSString*   message = kUnexpectConditionMessage;
+    NSString *message = kUnexpectConditionMessage;
     
-    if ([self.domain isEqualToString:(__bridge  NSString*)kCFErrorDomainCFNetwork])
-    {
+    if ([self.domain isEqualToString:(__bridge  NSString*)kCFErrorDomainCFNetwork]) {
         message = [self networkErrorMessage];
     }
-    else if ([self.domain isEqualToString:SBB_ERROR_DOMAIN])
-    {
-        message = [self bridgeErrorMessage];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    else if ([self respondsToSelector:@selector(bridgeErrorMessage)]) {
+        message = [self performSelector:@selector(bridgeErrorMessage)];
     }
-    
+#pragma clang diagnostic pop
+	
     return [NSString stringWithFormat:@"\n%@\n\nError code: %@", [self checkMessageForNonUserTerms:message], @(self.code)];
 }
 
@@ -315,41 +233,34 @@ static NSString * const oneTab = @"    ";
 #pragma mark - Friendly printouts
 // ---------------------------------------------------------
 
-- (NSString *) friendlyFormattedString
+- (NSString *)friendlyFormattedString
 {
     return [self friendlyFormattedStringAtLevel: 0];
 }
 
-- (NSString *) friendlyFormattedStringAtLevel: (NSUInteger) tabLevel
+- (NSString *)friendlyFormattedStringAtLevel:(NSUInteger)tabLevel
 {
     NSMutableString *output = [NSMutableString new];
-
     NSString *tab = [@"" stringByPaddingToLength: tabLevel * oneTab.length
                                       withString: oneTab
                                  startingAtIndex: 0];
 
     NSString *tabForNestedObjects = [NSString stringWithFormat: @"\n%@", tab];
-
     NSString *domain = self.domain.length > 0 ? self.domain : @"(none)";
 
     [output appendFormat: @"%@Code: %@\n", tab, @(self.code)];
     [output appendFormat: @"%@Domain: %@\n", tab, domain];
 
-    if (self.userInfo.count > 0)
-    {
-        for (NSString *key in [self.userInfo.allKeys sortedArrayUsingSelector: @selector (compare:)])
-        {
+    if (self.userInfo.count > 0) {
+        for (NSString *key in [self.userInfo.allKeys sortedArrayUsingSelector: @selector (compare:)]) {
             id value = self.userInfo [key];
             NSString *valueString = nil;
 
-            if ([value isKindOfClass: [NSError class]])
-            {
+            if ([value isKindOfClass: [NSError class]]) {
                 valueString = [value friendlyFormattedStringAtLevel: tabLevel + 1];
                 [output appendFormat: @"%@%@:\n%@", tab, key, valueString];
             }
-
-            else
-            {
+            else {
                 valueString = [NSString stringWithFormat: @"%@", value];
                 valueString = [valueString stringByReplacingOccurrencesOfString: @"\\n" withString: @"\n"];
                 valueString = [valueString stringByReplacingOccurrencesOfString: @"\\\"" withString: @"\""];
@@ -359,12 +270,10 @@ static NSString * const oneTab = @"    ";
         }
     }
 
-    if (tabLevel == 0)
-    {
+    if (tabLevel == 0)  {
         [output insertString: @"An error occurred. Available info:\n----- ERROR INFO -----\n" atIndex: 0];
 
-        if ([output characterAtIndex: output.length - 1] != '\n')
-        {
+        if ([output characterAtIndex: output.length - 1] != '\n') {
             [output appendString: @"\n"];
         }
 

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.m
@@ -34,16 +34,16 @@
 #import "NSError+APCAdditions.h"
 #import "APCLog.h"
 
-NSString * const kServerBusy                     = @"Thank you for your interest in this study. We are working hard to process the large volume of interest, and should be back up momentarily. Please try again soon.";
-NSString * const kUnexpectConditionMessage       = @"An unexpected network condition has occurred. Please try again soon.";
-NSString * const kNotConnectedMessage            = @"You are currently not connected to the Internet. Please try again when you are connected to a network.";
-NSString * const kServerMaintanenceMessage       = @"The study server is currently undergoing maintanence. Please try again soon.";
-NSString * const kAccountAlreadyExists           = @"An account has already been created for this email address. Please use a different email address, or sign in using the \"already participating\" link at the bottom of the Welcome page.";
-NSString * const kAccountDoesNotExists           = @"There is no account registered for this email address.";
-NSString * const kBadEmailAddress                = @"The email address submitted is not a valid email address. Please correct the email address and try again.";
-NSString * const kBadPasswordAddress             = @"The password you have entered is not a valid password.  Please try again.";
-NSString * const kNotReachableMessage            = @"We are currently not able to reach the study server. Please retry in a few moments.";
-NSString * const kInvalidEmailAddressOrPassword  = @"Entered email address or password is not valid. Please correct the email address or password and try again.";
+NSString * const kAPCServerBusyErrorMessage                     = @"Thank you for your interest in this study. We are working hard to process the large volume of interest, and should be back up momentarily. Please try again soon.";
+NSString * const kAPCUnexpectedConditionErrorMessage            = @"An unexpected network condition has occurred. Please try again soon.";
+NSString * const kAPCNotConnectedErrorMessage                   = @"You are currently not connected to the Internet. Please try again when you are connected to a network.";
+NSString * const kAPCServerUnderMaintanenceErrorMessage         = @"The study server is currently undergoing maintanence. Please try again soon.";
+NSString * const kAPCAccountAlreadyExistsErrorMessage           = @"An account has already been created for this email address. Please use a different email address, or sign in using the \"already participating\" link at the bottom of the Welcome page.";
+NSString * const kAPCAccountDoesNotExistErrorMessage            = @"There is no account registered for this email address.";
+NSString * const kAPCBadEmailAddressErrorMessage                = @"The email address submitted is not a valid email address. Please correct the email address and try again.";
+NSString * const kAPCBadPasswordErrorMessage                    = @"The password you have entered is not a valid password.  Please try again.";
+NSString * const kAPCNotReachableErrorMessage                   = @"We are currently not able to reach the study server. Please retry in a few moments.";
+NSString * const kAPCInvalidEmailAddressOrPasswordErrorMessage  = @"Entered email address or password is not valid. Please correct the email address or password and try again.";
 
 static NSString * const oneTab = @"    ";
 
@@ -78,19 +78,19 @@ static NSString * const oneTab = @"    ";
     NSString *message;
     
     if (self.code == 409) {
-        message = NSLocalizedString(kAccountAlreadyExists, nil);
+        message = NSLocalizedString(kAPCAccountAlreadyExistsErrorMessage, nil);
     }
     else if (self.code == 404) {
-        message = NSLocalizedString(kAccountDoesNotExists, nil);
+        message = NSLocalizedString(kAPCAccountDoesNotExistErrorMessage, nil);
     }
     else if (self.code >= 500 && self.code < 600) {
-        message = NSLocalizedString(kServerBusy, nil);
+        message = NSLocalizedString(kAPCServerBusyErrorMessage, nil);
     }
     else if (self.code == kCFURLErrorDNSLookupFailed || self.code == kCFURLErrorInternationalRoamingOff) {
-        message = NSLocalizedString(kNotConnectedMessage, nil);
+        message = NSLocalizedString(kAPCNotConnectedErrorMessage, nil);
     }
     else {
-        message = NSLocalizedString(kUnexpectConditionMessage, nil);
+        message = NSLocalizedString(kAPCUnexpectedConditionErrorMessage, nil);
     }
     
     return message;
@@ -99,7 +99,7 @@ static NSString * const oneTab = @"    ";
 
 - (NSString *)message
 {
-    NSString *message = kUnexpectConditionMessage;
+    NSString *message = kAPCUnexpectedConditionErrorMessage;
     
     if ([self.domain isEqualToString:(__bridge  NSString*)kCFErrorDomainCFNetwork]) {
         message = [self networkErrorMessage];

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.h
@@ -2,7 +2,7 @@
 //  NSError+Bridge.h
 //  AppCore
 //
-//  Copyright (c) 2015 Boston Children's Hospital. All rights reserved.
+//  Copyright (c) 2015 Apple. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -34,5 +34,7 @@
 #import "NSError+APCAdditions.h"
 
 @interface NSError (Bridge)
+
+- (NSString*)bridgeErrorMessage;
 
 @end

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.h
@@ -1,8 +1,8 @@
 //
 //  NSError+Bridge.h
-//  AppCore
+//  APCAppCore
 //
-//  Copyright (c) 2015 Apple. All rights reserved.
+// Copyright (c) 2015, Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.h
@@ -1,0 +1,38 @@
+//
+//  NSError+Bridge.h
+//  AppCore
+//
+//  Copyright (c) 2015 Boston Children's Hospital. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "NSError+APCAdditions.h"
+
+@interface NSError (Bridge)
+
+@end

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
@@ -1,0 +1,119 @@
+//
+//  NSError+Bridge.m
+//  AppCore
+//
+//  Copyright (c) 2015 Boston Children's Hospital. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "NSError+Bridge.h"
+#import <BridgeSDK/BridgeSDK.h>
+
+static NSString*    kSageMessageKey                 = @"message";
+static NSString*    kSageErrorsKey                  = @"errors";
+static NSString*    kSageErrorPasswordKey           = @"password";
+static NSString*    kSageErrorEmailKey              = @"email";
+static NSString*    kSageInvalidUsernameOrPassword  = @"Invalid username or password.";
+
+
+@implementation NSError (Bridge)
+
+
+- (NSString*)bridgeErrorMessage
+{
+	if (![self.domain isEqualToString:SBB_ERROR_DOMAIN]) {
+		return nil;
+	}
+	
+	NSString*   message;
+	id          code = self.userInfo[SBB_ORIGINAL_ERROR_KEY];
+	
+	if ([code isKindOfClass:[NSError class]])
+	{
+		NSError*    e = (NSError*)code;
+		
+		if (e.code == kCFURLErrorNotConnectedToInternet)
+		{
+			message = NSLocalizedString(kNotConnectedMessage, nil);
+		}
+		else
+		{
+			APCLogError(@"Network error: %@", code);
+		}
+	}
+	else if (self.code == 400)
+	{
+		// There are several messages that need to be displayed within the 400
+		// Extract the internal message then act appropriately.
+		NSDictionary * errors = [code valueForKey: kSageErrorsKey];
+		if([errors valueForKey: kSageErrorEmailKey])
+		{
+			message = NSLocalizedString(kBadEmailAddress, nil);
+		}
+		else if([errors valueForKey: kSageErrorPasswordKey])
+		{
+			message = NSLocalizedString(kBadPasswordAddress, nil);
+		} else
+		{
+			message = NSLocalizedString(kInvalidEmailAddressOrPassword, nil);
+		}
+		
+	}
+	else if (self.code == 409)
+	{
+		message = NSLocalizedString(kAccountAlreadyExists, nil);
+	}
+	else if (self.code == 404)
+	{
+		message = NSLocalizedString(kAccountDoesNotExists, nil);
+	}
+	else if ([code isEqual:@(503)] || self.code == 503)
+	{
+		message = NSLocalizedString(kServerBusy, nil);
+	}
+	else if ([code  isEqual: @(kSBBInternetNotConnected)])
+	{
+		message = NSLocalizedString(kNotConnectedMessage, nil);
+	}
+	else if ([code isEqual:@(kSBBServerNotReachable)])
+	{
+		message = NSLocalizedString(kNotReachableMessage, nil);
+	}
+	else if ([code isEqual:@(kSBBServerUnderMaintenance)])
+	{
+		message = NSLocalizedString(kServerMaintanenceMessage, nil);
+	}
+	else
+	{
+		message = NSLocalizedString(kUnexpectConditionMessage, nil);
+	}
+	
+	return message;
+}
+
+@end

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
@@ -2,7 +2,7 @@
 //  NSError+Bridge.m
 //  AppCore
 //
-//  Copyright (c) 2015 Boston Children's Hospital. All rights reserved.
+//  Copyright (c) 2015 Apple. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
@@ -1,8 +1,8 @@
 //
 //  NSError+Bridge.m
-//  AppCore
+//  APCAppCore
 //
-//  Copyright (c) 2015 Apple. All rights reserved.
+// Copyright (c) 2015, Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -34,11 +34,11 @@
 #import "NSError+Bridge.h"
 #import <BridgeSDK/BridgeSDK.h>
 
-static NSString*    kSageMessageKey                 = @"message";
-static NSString*    kSageErrorsKey                  = @"errors";
-static NSString*    kSageErrorPasswordKey           = @"password";
-static NSString*    kSageErrorEmailKey              = @"email";
-static NSString*    kSageInvalidUsernameOrPassword  = @"Invalid username or password.";
+static NSString *kSageMessageKey                 = @"message";
+static NSString *kSageErrorsKey                  = @"errors";
+static NSString *kSageErrorPasswordKey           = @"password";
+static NSString *kSageErrorEmailKey              = @"email";
+static NSString *kSageInvalidUsernameOrPassword  = @"Invalid username or password.";
 
 
 @implementation NSError (Bridge)
@@ -59,7 +59,7 @@ static NSString*    kSageInvalidUsernameOrPassword  = @"Invalid username or pass
 		
 		if (e.code == kCFURLErrorNotConnectedToInternet)
 		{
-			message = NSLocalizedString(kNotConnectedMessage, nil);
+			message = NSLocalizedString(kAPCNotConnectedErrorMessage, nil);
 		}
 		else
 		{
@@ -73,44 +73,44 @@ static NSString*    kSageInvalidUsernameOrPassword  = @"Invalid username or pass
 		NSDictionary * errors = [code valueForKey: kSageErrorsKey];
 		if([errors valueForKey: kSageErrorEmailKey])
 		{
-			message = NSLocalizedString(kBadEmailAddress, nil);
+			message = NSLocalizedString(kAPCBadEmailAddressErrorMessage, nil);
 		}
 		else if([errors valueForKey: kSageErrorPasswordKey])
 		{
-			message = NSLocalizedString(kBadPasswordAddress, nil);
+			message = NSLocalizedString(kAPCBadPasswordErrorMessage, nil);
 		} else
 		{
-			message = NSLocalizedString(kInvalidEmailAddressOrPassword, nil);
+			message = NSLocalizedString(kAPCInvalidEmailAddressOrPasswordErrorMessage, nil);
 		}
 		
 	}
 	else if (self.code == 409)
 	{
-		message = NSLocalizedString(kAccountAlreadyExists, nil);
+		message = NSLocalizedString(kAPCAccountAlreadyExistsErrorMessage, nil);
 	}
 	else if (self.code == 404)
 	{
-		message = NSLocalizedString(kAccountDoesNotExists, nil);
+		message = NSLocalizedString(kAPCAccountDoesNotExistErrorMessage, nil);
 	}
 	else if ([code isEqual:@(503)] || self.code == 503)
 	{
-		message = NSLocalizedString(kServerBusy, nil);
+		message = NSLocalizedString(kAPCServerBusyErrorMessage, nil);
 	}
 	else if ([code  isEqual: @(kSBBInternetNotConnected)])
 	{
-		message = NSLocalizedString(kNotConnectedMessage, nil);
+		message = NSLocalizedString(kAPCNotConnectedErrorMessage, nil);
 	}
 	else if ([code isEqual:@(kSBBServerNotReachable)])
 	{
-		message = NSLocalizedString(kNotReachableMessage, nil);
+		message = NSLocalizedString(kAPCNotReachableErrorMessage, nil);
 	}
 	else if ([code isEqual:@(kSBBServerUnderMaintenance)])
 	{
-		message = NSLocalizedString(kServerMaintanenceMessage, nil);
+		message = NSLocalizedString(kAPCServerUnderMaintanenceErrorMessage, nil);
 	}
 	else
 	{
-		message = NSLocalizedString(kUnexpectConditionMessage, nil);
+		message = NSLocalizedString(kAPCUnexpectedConditionErrorMessage, nil);
 	}
 	
 	return message;


### PR DESCRIPTION
NSError has a nice category to format errors for the end-user. This extension is used throughout AppCore but depends on the Bridge SDK.

This commit splits out the Bridge-specific errors but in the main extension still checks whether Bridge-specific errors are available, and falls back to using the `bridgeErrorMessage` method, as is currently the case.
