### PR TITLE
Create keychain category to handle passcode

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -322,6 +322,8 @@
 		CFFDEDFA1A95734000B25581 /* APCSetupTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = CFFDEDC01A95734000B25581 /* APCSetupTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CFFDEDFB1A95734000B25581 /* APCSetupTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = CFFDEDC11A95734000B25581 /* APCSetupTableViewCell.m */; };
 		CFFDEDFC1A95734000B25581 /* APCSetupTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CFFDEDC21A95734000B25581 /* APCSetupTableViewCell.xib */; };
+		EE028FE31AF94B36001C8251 /* APCKeychainStore+Passcode.h in Headers */ = {isa = PBXBuildFile; fileRef = EE028FE11AF94B36001C8251 /* APCKeychainStore+Passcode.h */; };
+		EE028FE41AF94B36001C8251 /* APCKeychainStore+Passcode.m in Sources */ = {isa = PBXBuildFile; fileRef = EE028FE21AF94B36001C8251 /* APCKeychainStore+Passcode.m */; };
 		F50738C01A682E12004CF100 /* APCDateRange.h in Headers */ = {isa = PBXBuildFile; fileRef = F50738BE1A682E12004CF100 /* APCDateRange.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F50738C11A682E12004CF100 /* APCDateRange.m in Sources */ = {isa = PBXBuildFile; fileRef = F50738BF1A682E12004CF100 /* APCDateRange.m */; };
 		F5306CCD1A8BE7F600732E60 /* ORKQuestionResult+APCHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F5306CCB1A8BE7F600732E60 /* ORKQuestionResult+APCHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1005,6 +1007,8 @@
 		CFFDEDC01A95734000B25581 /* APCSetupTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCSetupTableViewCell.h; sourceTree = "<group>"; };
 		CFFDEDC11A95734000B25581 /* APCSetupTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCSetupTableViewCell.m; sourceTree = "<group>"; };
 		CFFDEDC21A95734000B25581 /* APCSetupTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = APCSetupTableViewCell.xib; sourceTree = "<group>"; };
+		EE028FE11AF94B36001C8251 /* APCKeychainStore+Passcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "APCKeychainStore+Passcode.h"; sourceTree = "<group>"; };
+		EE028FE21AF94B36001C8251 /* APCKeychainStore+Passcode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "APCKeychainStore+Passcode.m"; sourceTree = "<group>"; };
 		F50738BE1A682E12004CF100 /* APCDateRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCDateRange.h; sourceTree = "<group>"; };
 		F50738BF1A682E12004CF100 /* APCDateRange.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCDateRange.m; sourceTree = "<group>"; };
 		F5179B2919D09128001DCCB7 /* APCAppCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = APCAppCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2253,6 +2257,8 @@
 				087255BF1ABA390500586492 /* APCJSONSerializer.m */,
 				F5B947751A73272C0034C522 /* APCKeychainStore.h */,
 				F5B947761A73272C0034C522 /* APCKeychainStore.m */,
+				EE028FE11AF94B36001C8251 /* APCKeychainStore+Passcode.h */,
+				EE028FE21AF94B36001C8251 /* APCKeychainStore+Passcode.m */,
 				F5B947771A73272C0034C522 /* APCSegmentedButton.h */,
 				F5B947781A73272C0034C522 /* APCSegmentedButton.m */,
 				F5B947791A73272C0034C522 /* APCTasksReminderManager.h */,
@@ -2995,6 +3001,7 @@
 				A7CFE4B71A8B05F4009A171C /* APCStudyOverviewCollectionViewController.h in Headers */,
 				F5F12A931A2F78490015982C /* APCStudyDetailsViewController.h in Headers */,
 				F5F12AEC1A2F78490015982C /* APCDashboardMessageTableViewCell.h in Headers */,
+				EE028FE31AF94B36001C8251 /* APCKeychainStore+Passcode.h in Headers */,
 				F5B947B11A73272C0034C522 /* UIFont+APCAppearance.h in Headers */,
 				369E28171A96B7A200D35DFA /* APCMedTrackerPrescriptionColor+Helper.h in Headers */,
 				F5F12A731A2F78490015982C /* APCConfirmationView.h in Headers */,
@@ -3564,6 +3571,7 @@
 				F5F129F71A2F78490015982C /* APCResult+Bridge.m in Sources */,
 				36B7D2561A8D848D0043F968 /* ORKAnswerFormat+Helper.m in Sources */,
 				08970F131A8D407600EA46C3 /* APCFoodInsight.m in Sources */,
+				EE028FE41AF94B36001C8251 /* APCKeychainStore+Passcode.m in Sources */,
 				712AB44F1A9E692400556DA2 /* APCMotionHistoryReporter.m in Sources */,
 				F5B947B61A73272C0034C522 /* APCDeviceHardware+APCHelper.m in Sources */,
 				369E280D1A96B7A200D35DFA /* APCMedTrackerPrescription+Helper.m in Sources */,

--- a/APCAppCore/APCAppCore/APCAppCore.h
+++ b/APCAppCore/APCAppCore/APCAppCore.h
@@ -271,7 +271,7 @@ FOUNDATION_EXPORT const unsigned char APCAppCoreVersionString[];
  ------------------------- */
 #import <APCAppCore/APCTableViewItem.h>
 #import <APCAppCore/APCGroupedScheduledTask.h>
-#import <APCAppCore/APCKeychainStore.h>
+#import <APCAppCore/APCKeychainStore+Passcode.h>
 #import <APCAppCore/APCPresentAnimator.h>
 #import <APCAppCore/APCFadeAnimator.h>
 #import <APCAppCore/APCScoring.h>

--- a/APCAppCore/APCAppCore/Library/Objects/APCKeychainStore+Passcode.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCKeychainStore+Passcode.h
@@ -1,0 +1,44 @@
+//
+//  APCKeychainStore+Passcode.h
+//  APCAppCore
+//
+//  Copyright (c) 2015 Boston Children's Hospital, Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "APCKeychainStore.h"
+
+@interface APCKeychainStore (Passcode)
+
+/** Store given passcode to the keychain. */
++ (void)setPasscode:(nonnull NSString *)passcode;
+
+/** Return the user's passcode, if any. */
++ (nullable NSString *)passcode;
+
+@end

--- a/APCAppCore/APCAppCore/Library/Objects/APCKeychainStore+Passcode.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCKeychainStore+Passcode.m
@@ -1,0 +1,52 @@
+//
+//  APCKeychainStore+Passcode.m
+//  APCAppCore
+//
+//  Copyright (c) 2015 Boston Children's Hospital, Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "APCKeychainStore+Passcode.h"
+
+static NSString * const kAPCPasscodeKey = @"APCPasscode";
+
+
+@implementation APCKeychainStore (Passcode)
+
++ (void)setPasscode:(nonnull NSString *)passcode
+{
+    NSParameterAssert([passcode length] > 0);
+    [APCKeychainStore setString:passcode forKey:kAPCPasscodeKey];
+}
+
++ (nullable NSString *)passcode
+{
+    return [APCKeychainStore stringForKey:kAPCPasscodeKey];
+}
+
+@end

--- a/APCAppCore/APCAppCore/Library/Objects/APCKeychainStore.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCKeychainStore.h
@@ -37,7 +37,7 @@
 
 + (NSString *)stringForKey:(NSString *)key;
 + (BOOL)setString:(NSString *)value forKey:(NSString *)key;
-+ (void) removeValueForKey: (NSString*) key;
-+ (void) resetKeyChain;
++ (void)removeValueForKey:(NSString *)key;
++ (void)resetKeyChain;
 
 @end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCUserInfoConstants.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCUserInfoConstants.h
@@ -103,6 +103,4 @@ static NSString * const kAPCMedicalInfoItemSleepTimeFormat     = @"hh:mm a";
 
 static NSString * const kAPCAppStateKey = @"APCAppState";
 
-static NSString * const kAPCPasscodeKey = @"APCPasscode";
-
 #endif

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCChangePasscodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCChangePasscodeViewController.m
@@ -92,7 +92,7 @@ typedef NS_ENUM(NSUInteger, APCPasscodeEntryType) {
     switch (self.entryType) {
         case kAPCPasscodeEntryTypeOld:
         {
-            if ([passcodeView.code isEqualToString:[APCKeychainStore stringForKey:kAPCPasscodeKey]]) {
+            if ([passcodeView.code isEqualToString:[APCKeychainStore passcode]]) {
                 self.textLabel.text = NSLocalizedString(@"Enter your new passcode", nil);
                 [passcodeView reset];
                 [passcodeView becomeFirstResponder];
@@ -143,7 +143,9 @@ typedef NS_ENUM(NSUInteger, APCPasscodeEntryType) {
 
 - (void)savePasscode
 {
-    [APCKeychainStore setString:self.passcode forKey:kAPCPasscodeKey];
+	if (self.passcode) {
+		[APCKeychainStore setPasscode:self.passcode];
+	}
     self.passcode = @"";
 }
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCChangePasscodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCChangePasscodeViewController.m
@@ -143,9 +143,9 @@ typedef NS_ENUM(NSUInteger, APCPasscodeEntryType) {
 
 - (void)savePasscode
 {
-	if (self.passcode) {
-		[APCKeychainStore setPasscode:self.passcode];
-	}
+    if (self.passcode) {
+        [APCKeychainStore setPasscode:self.passcode];
+    }
     self.passcode = @"";
 }
 

--- a/APCAppCore/APCAppCore/UI/ViewControllers/APCPasscodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/ViewControllers/APCPasscodeViewController.m
@@ -35,12 +35,13 @@
 #import <LocalAuthentication/LocalAuthentication.h>
 #import "UIAlertController+Helper.h"
 #import "APCPasscodeView.h"
+#import "APCLog.h"
+
 #import "UIColor+APCAppearance.h"
 #import "UIFont+APCAppearance.h"
-#import "APCKeychainStore.h"
+#import "APCKeychainStore+Passcode.h"
 #import "APCUserInfoConstants.h"
 #import "UIImage+APCHelper.h"
-#import "APCLog.h"
 
 @interface APCPasscodeViewController ()<APCPasscodeViewDelegate>
 
@@ -127,7 +128,7 @@
 - (void) passcodeViewDidFinish:(APCPasscodeView *) __unused passcodeView withCode:(NSString *) __unused code {
 
     if (self.passcodeView.code.length > 0) {
-        if ([self.passcodeView.code isEqualToString:[APCKeychainStore stringForKey:kAPCPasscodeKey]]) {
+        if ([self.passcodeView.code isEqualToString:[APCKeychainStore passcode]]) {
             //Authenticate
             if ([self.delegate respondsToSelector:@selector(passcodeViewControllerDidSucceed:)]) {
                 [self.delegate passcodeViewControllerDidSucceed:self];


### PR DESCRIPTION
Needed to be able to check the passcode from outside the core module, such in one's own app delegate, because the passcode field name constant is defined a static. Also eliminates programmer errors by not requiring to know the key.

The default key name is still **APCPasscode**, so unless app developers changed it this will not break compatibility.
