### PR TITLE
Fix Issue #9

### DIFF
--- a/APCAppCore/APCAppCore/Library/ScheduleExpression/Internals/APCPointSelector.m
+++ b/APCAppCore/APCAppCore/Library/ScheduleExpression/Internals/APCPointSelector.m
@@ -220,7 +220,11 @@
 
 	if (self.end == nil)
 	{
-		self.end = self.defaultEnd;
+        // Based on the unit tests, if this is not a wildcard or has a step defined, end should be nil.
+        if (self.isWildcard || self.step)
+        {
+            self.end = self.defaultEnd;
+        }
 	}
 	else if (self.end.integerValue > self.end.integerValue)
 	{


### PR DESCRIPTION
Quick fix to Issue #9.

Added an if statement to fix the failing tests based on the logic defined in the passing tests.  I basically concluded that if the APCPointSelector represented a wildcard or had steps defined, then the default end for the point selector should be used, otherwise it should remain nil.
