### PR TITLE
Ignoring tasks without taskId.

### DIFF
--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
@@ -515,8 +515,10 @@ typedef NS_ENUM(NSUInteger, APCActivitiesSections)
     for (APCScheduledTask *scheduledTask in ungroupedScheduledTasks) {
         NSString *taskId = scheduledTask.task.taskID;
         
-        if (![taskTypesArray containsObject:taskId]) {
-            [taskTypesArray addObject:taskId];
+        if (taskId) {
+            if (![taskTypesArray containsObject:taskId]) {
+                [taskTypesArray addObject:taskId];
+            }
         }
     }
     


### PR DESCRIPTION
A logic check to make sure any tasks that are being loaded (either from filesystem or server) have a task ID assigned to them, otherwise they will be ignored. [APC-2690]

Task ID is a required field and should never be nil; but there have been instances where tasks were being received without a task ID. Those instances were also causing a crash since there were no checks to guard against a nil being inserted into an NSArray.

Test:
Loaded multiple tasks, both from a staging server and filesystem, with nil task IDs with the result being that the app ignored all tasks with nil task IDs.
