### PR TITLE
Fix for the consent date being nil.

### DIFF
--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCEligibleViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCEligibleViewController.m
@@ -166,7 +166,15 @@ static NSString *kreturnControlOfTaskDelegate = @"returnControlOfTaskDelegate";
             user.consentSignatureImage = UIImagePNGRepresentation(consentResult.signature.signatureImage);
             
             NSDateFormatter *dateFormatter = [NSDateFormatter new];
-            dateFormatter.dateFormat = consentResult.signature.signatureDateFormatString;
+            
+            NSString *consentDateFormat = consentResult.signature.signatureDateFormatString;
+            
+            if (consentDateFormat) {
+                dateFormatter.dateFormat = consentDateFormat;
+            } else {
+                dateFormatter.dateStyle = NSDateFormatterShortStyle;
+            }
+            
             user.consentSignatureDate = [dateFormatter dateFromString:consentResult.signature.signatureDate];
             [((APCAppDelegate*)[UIApplication sharedApplication].delegate) dataSubstrate].currentUser.userConsented = YES;
             

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCEligibleViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCEligibleViewController.m
@@ -164,18 +164,8 @@ static NSString *kreturnControlOfTaskDelegate = @"returnControlOfTaskDelegate";
             APCUser *user = [self user];
             user.consentSignatureName = [consentResult.signature.givenName stringByAppendingFormat:@" %@",consentResult.signature.familyName];
             user.consentSignatureImage = UIImagePNGRepresentation(consentResult.signature.signatureImage);
+            user.consentSignatureDate = consentResult.startDate;
             
-            NSDateFormatter *dateFormatter = [NSDateFormatter new];
-            
-            NSString *consentDateFormat = consentResult.signature.signatureDateFormatString;
-            
-            if (consentDateFormat) {
-                dateFormatter.dateFormat = consentDateFormat;
-            } else {
-                dateFormatter.dateStyle = NSDateFormatterShortStyle;
-            }
-            
-            user.consentSignatureDate = [dateFormatter dateFromString:consentResult.signature.signatureDate];
             [((APCAppDelegate*)[UIApplication sharedApplication].delegate) dataSubstrate].currentUser.userConsented = YES;
             
             [self.consentVC dismissViewControllerAnimated:YES completion:^


### PR DESCRIPTION
Now checking if the -signatureDateFormatString method returned a nil, and if so using the NSDateFormatterShortStyle for the date. Doing so ensures that the date formatter is not using a nil format; which is why the consent date was being set to nil.

P.S. Pardon the typo in the commit message. It should should be 'date' not 'data'.
