### PR TITLE
Create an APCUserConsentSharingScope enum

### DIFF
--- a/APCAppCore/APCAppCore/Consent/APCConsentTask.h
+++ b/APCAppCore/APCAppCore/Consent/APCConsentTask.h
@@ -39,10 +39,11 @@
 
 @interface APCConsentTask : NSObject <ORKTask>
 
-@property (nonatomic, strong) ORKConsentDocument*       consentDocument;
-@property (nonatomic, strong) id<APCConsentRedirector>  redirector;
-@property (nonatomic, strong) NSString*                 failedMessageTag;
+@property (nonatomic, strong) ORKConsentDocument *consentDocument;
+@property (nonatomic, strong) id<APCConsentRedirector> redirector;
+@property (nonatomic, strong) NSString *failedMessageTag;
 
+@property (nonatomic, strong, readonly) ORKConsentSharingStep *sharingStep;
 
 - (instancetype)initWithIdentifier:(NSString*)identifier propertiesFileName:(NSString*)fileName;
 - (instancetype)initWithIdentifier:(NSString*)identifier propertiesFileName:(NSString*)fileName reasonForConsent:(NSString*)reason;

--- a/APCAppCore/APCAppCore/Consent/APCConsentTask.m
+++ b/APCAppCore/APCAppCore/Consent/APCConsentTask.m
@@ -104,8 +104,8 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
 @property (nonatomic, copy)   NSString*         investigatorLongDescription;
 @property (nonatomic, copy)   NSString*         sharingHtmlLearnMoreContent;
 
-@property (nonatomic, strong) ORKConsentSharingStep*  sharingStep;
-@property (nonatomic, strong) ORKVisualConsentStep*   visualStep;
+@property (nonatomic, strong, readwrite) ORKConsentSharingStep *sharingStep;
+@property (nonatomic, strong) ORKVisualConsentStep *visualStep;
 
 @property (nonatomic, strong) ORKStep*   lastQuestionStep;
 @property (nonatomic, strong) ORKStep*   resultQuestionStep;
@@ -348,34 +348,6 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     }
     else if ([step.identifier isEqualToString:kSharingTag])
     {
-        // Check for the sharing options answer and set the answer in the data model
-        ORKStepResult*  sharingStep = [result stepResultForStepIdentifier:kSharingTag];
-        if (sharingStep != nil)
-        {
-            NSArray *resultsOfSharingStep = [sharingStep results];
-            
-            if ([resultsOfSharingStep firstObject])
-            {
-                NSNumber*   sharingAnswer = [[[resultsOfSharingStep firstObject] choiceAnswers] firstObject];
-                
-                if (sharingAnswer != nil)
-                {
-                    APCAppDelegate* delegate = (APCAppDelegate*) [UIApplication sharedApplication].delegate;
-                    NSInteger       selected = -1;
-                    
-                    if ([sharingAnswer integerValue] == 0)
-                    {
-                        selected = SBBConsentShareScopeStudy;
-                    }
-                    else if ([sharingAnswer integerValue] == 1)
-                    {
-                        selected = SBBConsentShareScopeAll;
-                    }
-                    
-                    delegate.dataSubstrate.currentUser.sharedOptionSelection = [NSNumber numberWithInteger:selected];
-                }
-            }
-        }
         nextStep = findNextStep();
     }
     else if ([step.identifier isEqualToString:kSuccessMessageTag])

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.h
@@ -36,6 +36,13 @@
 #import <CoreData/CoreData.h>
 #import <UIKit/UIKit.h>
 
+typedef NS_ENUM(NSInteger, APCUserConsentSharingScope) {
+    APCUserConsentSharingScopeNone = 0,
+    APCUserConsentSharingScopeStudy,
+    APCUserConsentSharingScopeAll,
+};
+
+
 @interface APCUser : NSObject
 
 /*********************************************************************************/
@@ -59,6 +66,7 @@
 /*********************************************************************************/
 #pragma mark - Stored Properties in Core Data
 /*********************************************************************************/
+@property (nonatomic) APCUserConsentSharingScope sharingScope;      // NOT stored to CoreData, reflected in "sharedOptionSelection"
 @property (nonatomic) NSNumber *sharedOptionSelection;
 @property (nonatomic, strong) NSData *profileImage;
 

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.m
@@ -281,8 +281,36 @@ static NSString *const kSignedInKey = @"SignedIn";
 #pragma mark - Setters for Properties in Core Data
 /*********************************************************************************/
 
+- (void)setSharingScope:(APCUserConsentSharingScope)sharingScope
+{
+    _sharingScope = sharingScope;
+    switch (sharingScope) {
+        case APCUserConsentSharingScopeNone:
+            self.sharedOptionSelection = [NSNumber numberWithInteger:0];    // SBBConsentShareScopeNone
+            break;
+        case APCUserConsentSharingScopeStudy:
+            self.sharedOptionSelection = [NSNumber numberWithInteger:1];    // SBBConsentShareScopeStudy
+            break;
+        case APCUserConsentSharingScopeAll:
+            self.sharedOptionSelection = [NSNumber numberWithInteger:2];    // SBBConsentShareScopeAll
+            break;
+    }
+}
+
 - (void)setSharedOptionSelection:(NSNumber *)sharedOptionSelection
 {
+    switch (sharedOptionSelection.integerValue) {
+        case 0:
+            _sharingScope = APCUserConsentSharingScopeNone;
+            break;
+        case 1:
+            _sharingScope = APCUserConsentSharingScopeStudy;
+            break;
+        case 2:
+            _sharingScope = APCUserConsentSharingScopeAll;
+            break;
+    }
+    
     _sharedOptionSelection = sharedOptionSelection;
     [self updateStoredProperty:kSharedOptionSelection withValue:sharedOptionSelection];
 }

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCEligibleViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCEligibleViewController.m
@@ -159,21 +159,49 @@ static NSString *kreturnControlOfTaskDelegate = @"returnControlOfTaskDelegate";
         }
         
         //  if no signature (no consent result) then assume the user failed the quiz
-        if (consentResult != nil && consentResult.signature.requiresName && (consentResult.signature.givenName && consentResult.signature.familyName))
-        {
+        if (consentResult != nil && consentResult.signature.requiresName && (consentResult.signature.givenName && consentResult.signature.familyName)) {
             APCUser *user = [self user];
-            user.consentSignatureName = [consentResult.signature.givenName stringByAppendingFormat:@" %@",consentResult.signature.familyName];
-            user.consentSignatureImage = UIImagePNGRepresentation(consentResult.signature.signatureImage);
             
+            // extract the user's sharing choice
+            APCConsentTask *task = self.consentVC.task;
+            ORKConsentSharingStep *sharingStep = task.sharingStep;
+            
+            for (ORKStepResult* result in taskViewController.result.results) {
+                if ([result.identifier isEqualToString:sharingStep.identifier]) {
+                    for (ORKChoiceQuestionResult *choice in result.results) {
+                        if ([choice isKindOfClass:[ORKChoiceQuestionResult class]]) {
+                            NSNumber *answer = [choice.choiceAnswers firstObject];
+                            if ([answer isKindOfClass:[NSNumber class]]) {
+                                if (0 == answer.integerValue) {
+                                    user.sharingScope = APCUserConsentSharingScopeStudy;
+                                }
+                                else if (1 == answer.integerValue) {
+                                    user.sharingScope = APCUserConsentSharingScopeAll;
+                                }
+                                else {
+                                    APCLogDebug(@"Unknown sharing choice answer: %@", answer);
+                                }
+                            }
+                            else {
+                                APCLogDebug(@"Unknown sharing choice answer(s): %@", choice.choiceAnswers);
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            
+            // retrieve consent signature and date
             NSDateFormatter *dateFormatter = [NSDateFormatter new];
             dateFormatter.dateFormat = consentResult.signature.signatureDateFormatString;
             user.consentSignatureDate = [dateFormatter dateFromString:consentResult.signature.signatureDate];
-            [((APCAppDelegate*)[UIApplication sharedApplication].delegate) dataSubstrate].currentUser.userConsented = YES;
+            user.consentSignatureName = [consentResult.signature.givenName stringByAppendingFormat:@" %@",consentResult.signature.familyName];
+            user.consentSignatureImage = UIImagePNGRepresentation(consentResult.signature.signatureImage);
+            user.userConsented = YES;
             
-            [self.consentVC dismissViewControllerAnimated:YES completion:^
-             {
-                 [self startSignUp];
-             }];
+            [self.consentVC dismissViewControllerAnimated:YES completion:^{
+                [self startSignUp];
+            }];
         }
         else
         {

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
@@ -33,6 +33,7 @@
  
 #import "APCUserInfoViewController.h"
 
+@class APCUser;
 
 @protocol APCProfileViewControllerDelegate;
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -48,6 +48,7 @@
 #import "APCDataSubstrate.h"
 #import "APCConstants.h"
 #import "APCUtilities.h"
+#import "APCUser.h"
 #import "APCLog.h"
 
 #ifndef APC_HAVE_CONSENT
@@ -143,7 +144,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     
     [self setupDataFromJSONFile:@"StudyOverview"];
     
-    if (self.user.sharedOptionSelection && self.user.sharedOptionSelection.integerValue == 0) {
+    if (APCUserConsentSharingScopeNone == self.user.sharingScope) {
         self.participationLabel.text = NSLocalizedString(@"Your data is no longer being used for this study.", @"");
         self.leaveStudyButton.hidden = YES;
     }
@@ -721,7 +722,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
             [rowItems addObject:row];
         }
         
-        if (self.user.sharedOptionSelection != [NSNumber numberWithInteger:SBBConsentShareScopeNone]) {
+        if (APCUserConsentSharingScopeNone != self.user.sharingScope) {
             //  Instead of prevent the row from being added to the table, a better option would be to
             //  disable the row (grey it out and don't respond to taps)
             APCTableViewItem *field = [APCTableViewItem new];
@@ -1300,7 +1301,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     [self presentViewController:spinnerController animated:YES completion:nil];
     
     typeof(self) __weak weakSelf = self;
-    self.user.sharedOptionSelection = [NSNumber numberWithInteger:SBBConsentShareScopeNone];
+    self.user.sharingScope = APCUserConsentSharingScopeNone;
     [self.user withdrawStudyOnCompletion:^(NSError *error) {
         if (error) {
             APCLogError2 (error);

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
@@ -146,9 +146,9 @@ static NSInteger kNumberOfRows = 2;
     cell.textLabel.font = [UIFont appMediumFontWithSize:16.0f];
     cell.textLabel.textColor = [UIColor appSecondaryColor1];
     
-    if (indexPath.row == 0 && self.user.sharedOptionSelection.integerValue == SBBConsentShareScopeAll) {
+    if (indexPath.row == 0 && self.user.sharingScope == APCUserConsentSharingScopeAll) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    } else if (indexPath.row == 1 && self.user.sharedOptionSelection.integerValue == SBBConsentShareScopeStudy) {
+    } else if (indexPath.row == 1 && self.user.sharingScope == APCUserConsentSharingScopeStudy) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
     } else {
         cell.accessoryType = UITableViewCellAccessoryNone;
@@ -162,9 +162,9 @@ static NSInteger kNumberOfRows = 2;
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if (indexPath.row == 0) {
-        self.user.sharedOptionSelection = [NSNumber numberWithInteger:SBBConsentShareScopeAll];
+        self.user.sharingScope = APCUserConsentSharingScopeAll;
     } else if (indexPath.row == 1) {
-        self.user.sharedOptionSelection = [NSNumber numberWithInteger:SBBConsentShareScopeStudy];
+        self.user.sharingScope = APCUserConsentSharingScopeStudy;
     }
     
     APCSpinnerViewController *spinnerController = [[APCSpinnerViewController alloc] init];


### PR DESCRIPTION
This uncouples classes from the `SBBConsentShareScope` enum, which is defined in the BridgeSDK.

Adds a new property to `APCUser` but does **not** alter the CoreData model, the setters keep the new `user. sharingScope` and the existing `user. sharedOptionSelection` in sync.

Also fixes #37.
