### PR TITLE
Fix autolayout conflict on devices > 4"

### DIFF
--- a/APCAppCore/APCAppCore/UI/ViewControllers/APCPasscode.storyboard
+++ b/APCAppCore/APCAppCore/UI/ViewControllers/APCPasscode.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="aU5-mj-CXc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="aU5-mj-CXc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -42,10 +42,10 @@
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ygh-IW-MBW" customClass="APCButton">
-                                <rect key="frame" x="87" y="509" width="146" height="44"/>
+                                <rect key="frame" x="87" y="504" width="146" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="EvJ-jF-9aL"/>
-                                    <constraint firstAttribute="width" constant="146" id="uRh-eZ-N5W"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="146" id="uRh-eZ-N5W"/>
                                 </constraints>
                                 <state key="normal" title="Use Touch ID">
                                     <color key="titleColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
@@ -57,17 +57,22 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="ygh-IW-MBW" firstAttribute="leading" secondItem="MAj-Wy-kJa" secondAttribute="leading" constant="87" id="36S-gx-RqB"/>
                             <constraint firstItem="cKG-bB-Ib1" firstAttribute="top" secondItem="Cr6-0R-lJe" secondAttribute="bottom" constant="25" id="9c6-8y-rdu"/>
                             <constraint firstItem="aK3-gJ-vS8" firstAttribute="top" secondItem="cKG-bB-Ib1" secondAttribute="bottom" constant="20" id="ShE-ol-A7j"/>
                             <constraint firstItem="Cr6-0R-lJe" firstAttribute="top" secondItem="445-jw-ZAP" secondAttribute="bottom" constant="30" id="Ulo-o4-xDE"/>
                             <constraint firstItem="cKG-bB-Ib1" firstAttribute="leading" secondItem="MAj-Wy-kJa" secondAttribute="leadingMargin" constant="13" id="VqT-z2-DCt"/>
                             <constraint firstAttribute="centerX" secondItem="aK3-gJ-vS8" secondAttribute="centerX" id="WCk-vE-JxC"/>
-                            <constraint firstItem="fZn-Rb-vDa" firstAttribute="top" secondItem="ygh-IW-MBW" secondAttribute="bottom" constant="15" id="aDN-tl-Z7H"/>
+                            <constraint firstItem="fZn-Rb-vDa" firstAttribute="top" secondItem="ygh-IW-MBW" secondAttribute="bottom" constant="20" id="aDN-tl-Z7H"/>
                             <constraint firstAttribute="trailing" secondItem="ygh-IW-MBW" secondAttribute="trailing" constant="87" id="bOj-hf-Yga"/>
                             <constraint firstAttribute="centerX" secondItem="Cr6-0R-lJe" secondAttribute="centerX" id="ilQ-JB-VGR"/>
+                            <constraint firstAttribute="centerX" secondItem="ygh-IW-MBW" secondAttribute="centerX" id="pdS-Z8-Kpx"/>
                             <constraint firstAttribute="trailingMargin" secondItem="cKG-bB-Ib1" secondAttribute="trailing" constant="12" id="xlr-kq-iLO"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="bOj-hf-Yga"/>
+                            </mask>
+                        </variation>
                     </view>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>


### PR DESCRIPTION
The "Use Touch ID" button had a fixed left margin, fixed width and fixed right margin. And it used only 15px from the bottom. This commit removes the margins for a center-in-container constraint, makes the width a greater-than or equal and uses a standard 20px distance from the bottom.
