### PR TITLE
Use correct method name.

### DIFF
--- a/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/APCPassiveDisplacementTrackingDataUploader.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/APCPassiveDisplacementTrackingDataUploader.m
@@ -157,7 +157,7 @@ static  NSString* const kLon                                    = @"lon";
             [APCPassiveDataSink createOrAppendString:outString
                                               toFile:[strongSelf.folder stringByAppendingPathComponent:kCSVFilename]];
             
-            [strongSelf flushDataIfNeeded];
+            [strongSelf checkIfDataNeedsToBeFlushed];
         }
 
         [self setBaseTrackingLocation:manager.location];

--- a/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.h
@@ -71,7 +71,7 @@ typedef NSString* (^APCQuantityCSVSerializer)(id dataSample, HKUnit*);
 - (void)didReceiveUpdatedValuesFromCollector:(id)results;
 - (void)didReceiveUpdatedValueFromCollector:(id)result;
 - (void)processUpdatesFromCollector:(id)quantitySample;
-- (void)flushDataIfNeeded;
+- (void)checkIfDataNeedsToBeFlushed;
 
 + (void)createOrAppendString:(NSString*)string toFile:(NSString*)path;
 + (void)createOrReplaceString:(NSString*)string toFile:(NSString*)path;

--- a/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
@@ -110,7 +110,7 @@ static NSUInteger       kDaysPerWeek        = 7;
         [APCPassiveDataSink createOrAppendString:stringToWrite
                                           toFile:[strongSelf.folder stringByAppendingPathComponent:kCSVFilename]];
         
-        [strongSelf flushDataIfNeeded];
+        [strongSelf checkIfDataNeedsToBeFlushed];
     }];
 }
 


### PR DESCRIPTION
Use correct method name. The method name was updated but the method calls were not.
