### PR TITLE
Use identifiers instead of the "displacement" constant to label specific file uploads.

### DIFF
--- a/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
@@ -44,7 +44,6 @@ static NSString *const  kStartDateKey       = @"startDate";
 static NSString *const  kEndDateKey         = @"endDate";
 static NSString *const  kInfoFilename       = @"info.json";
 static NSString *const  kCSVFilename        = @"data.csv";
-static NSString *const  kItemIdentifier     = @"displacement";
 static long long        kKBPerMB            = 1024;
 static long long        kBytesPerKB         = 1024;
 static NSUInteger       kSecsPerMin         = 60;
@@ -366,7 +365,7 @@ static NSUInteger       kDaysPerWeek        = 7;
     NSString*   csvFilePath = [self.folder stringByAppendingPathComponent:kCSVFilename];
 
     BOOL success = [APCDataArchiverAndUploader uploadFileAtPath:csvFilePath
-                                             withTaskIdentifier:kItemIdentifier
+                                             withTaskIdentifier:self.identifier
                                                  andTaskRunUuid:nil
                                                  returningError:&error];
     
@@ -414,6 +413,8 @@ static NSUInteger       kDaysPerWeek        = 7;
                        kIdentifierKey   : sinkIdentifier,
                        kStartDateKey    : dateString
                        };
+    
+    self.infoDictionary = infoDictionary;
     
     NSString*       infoJSON        = [infoDictionary JSONString];
     
@@ -530,7 +531,7 @@ static NSUInteger       kDaysPerWeek        = 7;
 {
     if (_sizeThreshold == 0)
     {
-        _sizeThreshold = 1 * kKBPerMB * kBytesPerKB;
+        _sizeThreshold = 50 * kBytesPerKB;
     }
     
     return _sizeThreshold;
@@ -540,7 +541,7 @@ static NSUInteger       kDaysPerWeek        = 7;
 {
     if (_stalenessInterval == 0)
     {
-        _stalenessInterval = 1 * kDaysPerWeek * kHoursPerDay * kMinsPerHour * kSecsPerMin;
+        _stalenessInterval = kHoursPerDay * kMinsPerHour * kSecsPerMin;
     }
     
     return _stalenessInterval;

--- a/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
@@ -45,11 +45,9 @@ static NSString *const  kEndDateKey         = @"endDate";
 static NSString *const  kInfoFilename       = @"info.json";
 static NSString *const  kCSVFilename        = @"data.csv";
 static long long        kKBPerMB            = 1024;
-static long long        kBytesPerKB         = 1024;
 static NSUInteger       kSecsPerMin         = 60;
 static NSUInteger       kMinsPerHour        = 60;
 static NSUInteger       kHoursPerDay        = 24;
-static NSUInteger       kDaysPerWeek        = 7;
 
 @implementation APCPassiveDataSink
 

--- a/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NewDataCollector/Data Sink/APCPassiveDataSink.m
@@ -539,7 +539,7 @@ static NSUInteger       kHoursPerDay        = 24;
 {
     if (_stalenessInterval == 0)
     {
-        _stalenessInterval = kHoursPerDay * kMinsPerHour * kSecsPerMin;
+        _stalenessInterval = 1 * kHoursPerDay * kMinsPerHour * kSecsPerMin;
     }
     
     return _stalenessInterval;


### PR DESCRIPTION
Use identifiers instead of the "displacement" constant to label specific file uploads from passive data sink. Lower upload thresholds for passive data collector. 
