### PR TITLE
Changing default value for Schedule.maxCount during data migration.

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCDataMigrationPolicy_Model4ToModel6.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCDataMigrationPolicy_Model4ToModel6.m
@@ -157,6 +157,22 @@ static NSString * const kAPCErrorFetchingUsersSuggestion = @"Unable to fetch use
     return versionNumber;
 }
 
+/**
+ Version 6 of the model introduces a maxCount field in the Schedule object,
+ with a default value of 0.  We later decided the default should be nil
+ unless explicitly set.  This method lets us fix the default value for
+ schedules migrated from v4 to v6.  New schedules get their values set
+ properly at creation time.
+
+ @param scheduleFromV6  The "destination" schedule object:  the object created
+ after the migration process has been performed on a schedule from version 4.
+ For inspection during debugging.
+ */
+- (NSNumber *) repairImproperDefaultMaxCountInNewSchedule: (APCSchedule *) __unused scheduleFromV6
+{
+    return nil;
+}
+
 
 
 // ---------------------------------------------------------

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCMappingModel4ToModel6.xcmappingmodel/xcmapping.xml
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCMappingModel4ToModel6.xcmappingmodel/xcmapping.xml
@@ -557,6 +557,9 @@ EwcIExQZGiInLC0wMTU6O0BESkxVJG51bGzVCQoLDA0ODxAREllOU09wZXJhbmReTlNTZWxlY3Rvck5h
         <relationship name="entitymapping" type="1/1" destination="XDDEVENTITYMAPPING" idrefs="z129"></relationship>
     </object>
     <object type="XDDEVATTRIBUTEMAPPING" id="z206">
+        <attribute name="valueexpressiondata" type="binary">YnBsaXN0MDDUAQIDBAUGMzRYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKsH
+CBMUGRoiJyorLlUkbnVsbNUJCgsMDQ4PEBESWU5TT3BlcmFuZF5OU1NlbGVjdG9yTmFtZV8QEE5TRXhwcmVzc2lvblR5cGVbTlNBcmd1bWVudHNWJGNsYXNzgAOAAhAEgAaACl8QK3JlcGFpckltcHJvcGVyRGVmYXVsdE1heENvdW50SW5OZXdTY2hlZHVsZTrTFQsNFhcYWk5TVmFyaWFibGWABBACgAVcZW50aXR5UG9saWN50hscHR5aJGNsYXNzbmFtZVgkY2xhc3Nlc18QFE5TVmFyaWFibGVFeHByZXNzaW9uox8gIV8QFE5TVmFyaWFibGVFeHByZXNzaW9uXE5TRXhwcmVzc2lvblhOU09iamVjdNIjDSQmWk5TLm9iamVjdHOhJYAHgAnTFQsNKBcYgAiABVtkZXN0aW5hdGlvbtIbHCwtV05TQXJyYXmiLCHSGxwvMF8QFE5TRnVuY3Rpb25FeHByZXNzaW9uozEyIV8QFE5TRnVuY3Rpb25FeHByZXNzaW9uXE5TRXhwcmVzc2lvbl8QD05TS2V5ZWRBcmNoaXZlctE1NlRyb290gAEACAARABoAIwAtADIANwBDAEkAVABeAG0AgACMAJMAlQCXAJkAmwCdAMsA0gDdAN8A4QDjAPAA9QEAAQkBIAEkATsBSAFRAVYBYQFjAWUBZwFuAXABcgF+AYMBiwGOAZMBqgGuAcUB0gHkAecB7AAAAAAAAAIBAAAAAAAAADcAAAAAAAAAAAAAAAAAAAHu
+</attribute>
         <attribute name="name" type="string">maxCount</attribute>
         <relationship name="entitymapping" type="1/1" destination="XDDEVENTITYMAPPING" idrefs="z173"></relationship>
     </object>


### PR DESCRIPTION
During migration from CoreData schema v4 to v6, all existing Schedules on the user's phone get a new maxCount field, set to 0.  It should default to nil.  This pull request does that.
