### PR TITLE
Reset method name to use stable version of Researchkit

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
@@ -549,7 +549,7 @@ static APCDummyObject * _dummyObject;
     NSMutableArray * options = [NSMutableArray array];
     [localConstraints.enumeration enumerateObjectsUsingBlock:^(SBBSurveyQuestionOption* option, NSUInteger __unused idx, BOOL * __unused stop) {
         NSString * detailText = option.detail.length > 0 ? option.detail : nil;
-        ORKTextChoice * choice = [ORKTextChoice choiceWithText:option.label detailText:detailText value:option.value exclusive:NO];
+        ORKTextChoice * choice = [ORKTextChoice choiceWithText:option.label detailText:detailText value:option.value];
         [options addObject: choice];
     }];
     if (localConstraints.allowOtherValue) {


### PR DESCRIPTION
@YuanZhu-apple I'm resetting the method name which is from the stable branch of Researchkit.
