### PR TITLE
Use a callback with Motion History Reporter

### DIFF
--- a/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.h
+++ b/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.h
@@ -3,6 +3,7 @@
 //  APCAppCore 
 // 
 // Copyright (c) 2015, Apple Inc. All rights reserved. 
+// Copyright (c) 2015, Boston Children's Hospital. All rights reserved. 
 // 
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -34,18 +35,23 @@
 
 #import <Foundation/Foundation.h>
 
+/// Callback when motion history reporter is done.
+typedef void (^APCMotionHistoryReporterCallback)(NSArray * __nullable motionReports, NSError * __nullable error);
+
 @interface APCMotionHistoryReporter : NSObject
-{
-    
-}
 
-+(APCMotionHistoryReporter *)sharedInstance;
+NS_ASSUME_NONNULL_BEGIN
++ (APCMotionHistoryReporter *)sharedInstance;
 
+/** Start motion history collection. You will need to listen to the "" notification and call the shared instance's `retrieveMotionReport`. */
+- (void)startMotionCoProcessorDataFrom:(NSDate *)startDate andEndDate:(NSDate *)endDate andNumberOfDays:(NSInteger)numberOfDays;
 
--(void)startMotionCoProcessorDataFrom:(NSDate *)startDate andEndDate:(NSDate *)endDate andNumberOfDays:(NSInteger)numberOfDays;
+/** Start motion history collection and return the report in a callback. */
+- (void)startMotionCoProcessorDataFrom:(NSDate *)startDate andEndDate:(NSDate *)endDate andNumberOfDays:(NSInteger)numberOfDays callback:(APCMotionHistoryReporterCallback)callback;
 
--(BOOL)isDataReady;
+- (BOOL)isDataReady;
 
--(NSArray*)retrieveMotionReport;
+- (NSArray *)retrieveMotionReport;
+NS_ASSUME_NONNULL_END
 
 @end

--- a/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.h
+++ b/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.h
@@ -43,10 +43,18 @@ typedef void (^APCMotionHistoryReporterCallback)(NSArray * __nullable motionRepo
 NS_ASSUME_NONNULL_BEGIN
 + (APCMotionHistoryReporter *)sharedInstance;
 
-/** Start motion history collection. You will need to listen to the "" notification and call the shared instance's `retrieveMotionReport`. */
+/** Start motion history collection. You will need to listen to the "APCMotionHistoryReporterDoneNotification" notification and call the
+ *  shared instance's `retrieveMotionReport`.
+ *
+ *  If you start the history reporter while it hasn't finished a previous run, nothing will happen.
+ */
 - (void)startMotionCoProcessorDataFrom:(NSDate *)startDate andEndDate:(NSDate *)endDate andNumberOfDays:(NSInteger)numberOfDays;
 
-/** Start motion history collection and return the report in a callback. */
+/** Start motion history collection and return the report in a callback.
+ *
+ *  If you start the history reporter while it hasn't finished a previous run, the callback will be called with an error in the
+ *  "APCAppCoreErrorDomain" with error code 51.
+ */
 - (void)startMotionCoProcessorDataFrom:(NSDate *)startDate andEndDate:(NSDate *)endDate andNumberOfDays:(NSInteger)numberOfDays callback:(APCMotionHistoryReporterCallback)callback;
 
 - (BOOL)isDataReady;

--- a/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.m
+++ b/APCAppCore/APCAppCore/Library/APCMotionHistoryReporter.m
@@ -99,7 +99,10 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
 	}];
 }
 
-- (void)startMotionCoProcessorDataFrom:(NSDate * __nonnull)startDate andEndDate:(NSDate * __nonnull)endDate andNumberOfDays:(NSInteger)numberOfDays callback:(APCMotionHistoryReporterCallback __nonnull)callback{
+- (void)startMotionCoProcessorDataFrom:(NSDate * __nonnull)startDate andEndDate:(NSDate * __nonnull)endDate andNumberOfDays:(NSInteger)numberOfDays callback:(APCMotionHistoryReporterCallback __nonnull)callback {
+	NSParameterAssert(startDate);
+	NSParameterAssert(endDate);
+	NSParameterAssert(callback);
 	if (_doneCallback) {
 		callback(nil, [NSError errorWithDomain:@"APCAppCoreErrorDomain" code:51 userInfo:@{NSLocalizedDescriptionKey: @"Motion History Reporter is already processing motion history, wait for it to complete"}]);
 		return;
@@ -117,6 +120,11 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
 {
 	NSParameterAssert(startDate);
 	NSParameterAssert(endDate);
+	if (numberOfDays == 0) {
+		isTheDataReady = true;
+		[self callDoneCallbackWithReports:[motionReport copy] error:nil];
+		return;
+	}
 	
     NSInteger               numberOfDaysBack = numberOfDays * -1;
     NSDateComponents        *components = [[NSDateComponents alloc] init];
@@ -142,8 +150,6 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
                                                       toQueue:[NSOperationQueue new]
                                                   withHandler:^(NSArray *activities, NSError * __unused error) {
                                                      
-                                                      if (numberOfDays > 0)
-                                                      {
                                                           NSDate *lastActivity_started;
 
                                                           NSTimeInterval totalUnknownTime = 0.0;
@@ -417,14 +423,6 @@ static APCMotionHistoryReporter __strong *sharedInstance = nil;
                                                           
                                         
                                                           
-                                                      }
-                                                      
-                                                      if (numberOfDays == 0) {
-                                                          isTheDataReady = true;
-														  [self callDoneCallbackWithReports:[motionReport copy] error:nil];
-                                                      }
-                                                                                                      
-        
     }];
 }
 


### PR DESCRIPTION
- New, additional method to collect motion data and be notified on a callback
- Preserves the current method with a notification center notification but uses the callback internally
- Add Swift nullable annotations
