### PR TITLE
Adding abstract method to execute migration after scheduler's first import. 

### DIFF
--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
@@ -83,7 +83,7 @@ static NSString*    const kDatabaseName                     = @"db.sqlite";
 - (void) showNeedsEmailVerification;
 - (void) setUpRootViewController: (UIViewController*) viewController;
 - (void) setUpTasksReminder;
-
+- (void)performMigrationAfterFirstImport;
 - (void)performMigrationFrom:(NSInteger)previousVersion currentVersion:(NSInteger)currentVersion;
 - (void)performMigrationAfterDataSubstrateFrom:(NSInteger)previousVersion currentVersion:(NSInteger)currentVersion;
 - (NSString *) applicationDocumentsDirectory;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -114,8 +114,12 @@ static NSUInteger   const kIndexOfProfileTab                = 3;
     [self initializeBridgeServerConnection];
     [self initializeAppleCoreStack];
 
-    [self.scheduler loadTasksAndSchedulesFromDiskAndThenUseThisQueue: nil
-                                                    toDoThisWhenDone: nil];
+    // ...to this:
+    [self.scheduler loadTasksAndSchedulesFromDiskAndThenUseThisQueue: [NSOperationQueue mainQueue]
+                                                    toDoThisWhenDone: ^(NSError *errorFetchingOrLoading)
+    {
+        [self performMigrationAfterFirstImport];
+    }];
 
     [self registerNotifications];
     [self setUpHKPermissions];
@@ -160,6 +164,11 @@ static NSUInteger   const kIndexOfProfileTab                = 3;
 - (NSUInteger)obtainPreviousVersion {
     NSUserDefaults* defaults        = [NSUserDefaults standardUserDefaults];
     return (NSUInteger) [defaults integerForKey:@"previousVersion"];
+}
+
+- (void)performMigrationAfterFirstImport
+{
+    /* abstract implementation */
 }
 
 - (void)performMigrationFrom:(NSInteger) __unused previousVersion currentVersion:(NSInteger)__unused currentVersion

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -114,9 +114,8 @@ static NSUInteger   const kIndexOfProfileTab                = 3;
     [self initializeBridgeServerConnection];
     [self initializeAppleCoreStack];
 
-    // ...to this:
-    [self.scheduler loadTasksAndSchedulesFromDiskAndThenUseThisQueue: [NSOperationQueue mainQueue]
-                                                    toDoThisWhenDone: ^(NSError *errorFetchingOrLoading)
+    [self.scheduler loadTasksAndSchedulesFromDiskAndThenUseThisQueue:[NSOperationQueue mainQueue]
+                                                    toDoThisWhenDone:^(NSError* errorFetchingOrLoading)
     {
         [self performMigrationAfterFirstImport];
     }];
@@ -127,6 +126,7 @@ static NSUInteger   const kIndexOfProfileTab                = 3;
     [self setUpTasksReminder];
     [self performDemographicUploadIfRequired];
     [self showAppropriateVC];
+    
     return YES;
 }
 

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -117,7 +117,10 @@ static NSUInteger   const kIndexOfProfileTab                = 3;
     [self.scheduler loadTasksAndSchedulesFromDiskAndThenUseThisQueue:[NSOperationQueue mainQueue]
                                                     toDoThisWhenDone:^(NSError* errorFetchingOrLoading)
     {
-        [self performMigrationAfterFirstImport];
+        if(!errorFetchingOrLoading)
+        {
+            [self performMigrationAfterFirstImport];
+        }
     }];
 
     [self registerNotifications];


### PR DESCRIPTION
Adding abstract method to execute migration after scheduler's first import. 
