### PR TITLE
Fix issue related to Average Label in Landscape Graphs

### DIFF
--- a/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.h
@@ -188,7 +188,17 @@
 
 @property (nonatomic, strong) NSAttributedString *legend;
 
-+(NSAttributedString *)legendForSeries1:(NSString *)series1 series2:(NSString *)series2;
+@property (nonatomic) BOOL hidesUnitString;
+
+@property (nonatomic) BOOL hidesDetailText;
+
++ (NSAttributedString *)legendForSeries1:(NSString *)series1 series2:(NSString *)series2;
+
+- (NSString *)averageValueString;
+
+- (NSString *)minimumValueString;
+
+- (NSString *)maximumValueString;
 
 @end
 

--- a/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
@@ -189,34 +189,26 @@
 - (NSString *)averageValueString
 {
     double averageValue = [[self.graphData averageDataPoint] doubleValue];
-    
-    HKUnit *unit = self.graphData.unit;
-    NSString *unitString = (self.hidesUnitString || !unit) ? @"" : unit.unitString;
-    NSString *averageString = [NSString stringWithFormat:NSLocalizedString(@"%0.0f %@", nil), averageValue, unitString];
-    
-    return averageString;
+    return [self stringWithDoubleValue:averageValue];
 }
 
 - (NSString *)minimumValueString
 {
     double minValue = [[self.graphData minimumDataPoint] doubleValue];
-    
-    HKUnit *unit = self.graphData.unit;
-    NSString *unitString = (self.hidesUnitString || !unit) ? @"" : unit.unitString;
-    NSString *minString = [NSString stringWithFormat:NSLocalizedString(@"%0.0f %@", nil), minValue, unitString];
-    
-    return minString;
+    return [self stringWithDoubleValue:minValue];
 }
 
 - (NSString *)maximumValueString
 {
     double maxValue = [[self.graphData maximumDataPoint] doubleValue];
-    
+    return [self stringWithDoubleValue:maxValue];
+}
+
+- (NSString *)stringWithDoubleValue: (double)value
+{
     HKUnit *unit = self.graphData.unit;
     NSString *unitString = (self.hidesUnitString || !unit) ? @"" : unit.unitString;
-    NSString *maxString = [NSString stringWithFormat:NSLocalizedString(@"%0.0f %@", nil), maxValue, unitString];
-    
-    return maxString;
+    return [NSString stringWithFormat:NSLocalizedString(@"%0.0f %@", nil), value, unitString];
 }
 
 @end

--- a/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
@@ -155,8 +155,7 @@
 
 @implementation APCTableViewDashboardGraphItem
 
-+(NSAttributedString *)legendForSeries1:(NSString *) series1 series2:(NSString *)series2
-{
++(NSAttributedString *)legendForSeries1:(NSString *) series1 series2:(NSString *)series2{
     
     NSAssert(series1 != nil, @"Pass a valid series 1 name");
     
@@ -186,6 +185,40 @@
     return legend;
     
 }
+
+- (NSString *)averageValueString
+{
+    double averageValue = [[self.graphData averageDataPoint] doubleValue];
+    
+    HKUnit *unit = self.graphData.unit;
+    NSString *unitString = (self.hidesUnitString || !unit) ? @"" : unit.unitString;
+    NSString *averageString = [NSString stringWithFormat:NSLocalizedString(@"%0.0f %@", nil), averageValue, unitString];
+    
+    return averageString;
+}
+
+- (NSString *)minimumValueString
+{
+    double minValue = [[self.graphData minimumDataPoint] doubleValue];
+    
+    HKUnit *unit = self.graphData.unit;
+    NSString *unitString = (self.hidesUnitString || !unit) ? @"" : unit.unitString;
+    NSString *minString = [NSString stringWithFormat:NSLocalizedString(@"%0.0f %@", nil), minValue, unitString];
+    
+    return minString;
+}
+
+- (NSString *)maximumValueString
+{
+    double maxValue = [[self.graphData maximumDataPoint] doubleValue];
+    
+    HKUnit *unit = self.graphData.unit;
+    NSString *unitString = (self.hidesUnitString || !unit) ? @"" : unit.unitString;
+    NSString *maxString = [NSString stringWithFormat:NSLocalizedString(@"%0.0f %@", nil), maxValue, unitString];
+    
+    return maxString;
+}
+
 @end
 
 @implementation APCTableViewDashboardMessageItem


### PR DESCRIPTION
Fix issue where the average label doesn't change with time scale changes in Landscape graph.
- Pull corresponding unit from the HKUnit property in APCScoring.
- Add support to hide/unhide the units.
- Add helper methods for average/Min/Max value strings.
