### PR TITLE
Improve APCPieGraphViewDelegate

### DIFF
--- a/APCAppCore/APCAppCore/UI/Components/APCPieGraphView.h
+++ b/APCAppCore/APCAppCore/UI/Components/APCPieGraphView.h
@@ -77,7 +77,7 @@
 
 @required
 
-- (NSInteger)numberOfSegmentsInPieGraphView;
+- (NSInteger)numberOfSegmentsInPieGraphView:(APCPieGraphView *)pieGraphView;
 
 - (CGFloat)pieGraphView:(APCPieGraphView *)pieGraphView valueForSegmentAtIndex:(NSInteger)index;
 

--- a/APCAppCore/APCAppCore/UI/Components/APCPieGraphView.m
+++ b/APCAppCore/APCAppCore/UI/Components/APCPieGraphView.m
@@ -197,8 +197,8 @@ static CGFloat const kAnimationDuration = 0.35f;
 {
     NSInteger count = 0;
     
-    if ([self.datasource respondsToSelector:@selector(numberOfSegmentsInPieGraphView)]) {
-        count = [self.datasource numberOfSegmentsInPieGraphView];
+    if ([self.datasource respondsToSelector:@selector(numberOfSegmentsInPieGraphView:)]) {
+        count = [self.datasource numberOfSegmentsInPieGraphView:self];
     }
     
     return count;

--- a/APCAppCore/APCAppCore/UI/ViewControllers/Activity Tracking/APCActivityTrackingStepViewController.m
+++ b/APCAppCore/APCAppCore/UI/ViewControllers/Activity Tracking/APCActivityTrackingStepViewController.m
@@ -311,7 +311,7 @@ static NSInteger const kRegularFontSize = 17;
 
 #pragma mark - PieGraphView Delegates
 
--(NSInteger)numberOfSegmentsInPieGraphView
+-(NSInteger)numberOfSegmentsInPieGraphView:(APCPieGraphView *) __unused pieGraphView
 {
     return [self.allocationDataset count];
 }


### PR DESCRIPTION
To allow one delegate to handle more than one pie graph.
