### PR TITLE
Add override point to create custom permissions manager

### DIFF
--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.h
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.h
@@ -47,9 +47,18 @@ typedef NS_ENUM(NSUInteger, APCPermissionStatus) {
 @property (copy, nonatomic) NSArray *userInfoItemTypes;
 @property (copy, nonatomic) NSArray *signUpPermissionTypes;
 
+/**
+ *  Designated initializer.
+ *
+ *  @param characteristicTypesToRead Array of strings defined as `HKCharacteristicTypeIdentifier*` constants
+ *  @param quantityTypesToRead Array of strings defined as `HKQuantityTypeIdentifier*` constants or dictionaries encoding other types (TODO: improve and document)
+ *  @param quantityTypesToWrite Array of strings defined as `HKQuantityTypeIdentifier*` constants or dictionaries encoding other types (TODO: improve and document)
+ *  @param userInfoItemTypes Array of numbers representing `APCUserInfoItemType` types
+ *  @param signUpPermissionTypes Array of numbers representing `APCSignUpPermissionsType` types
+ */
 - (id)initWithHealthKitCharacteristicTypesToRead:(NSArray *)characteristicTypesToRead
                     healthKitQuantityTypesToRead:(NSArray *)quantityTypesToRead
-                   healthKitQuantityTypesToWrite:(NSArray *)QuantityTypesToWrite
+                   healthKitQuantityTypesToWrite:(NSArray *)quantityTypesToWrite
                                userInfoItemTypes:(NSArray *)userInfoItemTypes
                            signUpPermissionTypes:(NSArray *)signUpPermissionTypes;
 

--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
@@ -87,7 +87,7 @@ typedef NS_ENUM(NSUInteger, APCPermissionsErrorCode) {
 
 - (id)initWithHealthKitCharacteristicTypesToRead:(NSArray *)characteristicTypesToRead
                     healthKitQuantityTypesToRead:(NSArray *)quantityTypesToRead
-                   healthKitQuantityTypesToWrite:(NSArray *)QuantityTypesToWrite
+                   healthKitQuantityTypesToWrite:(NSArray *)quantityTypesToWrite
                                userInfoItemTypes:(NSArray *)userInfoItemTypes
                            signUpPermissionTypes:(NSArray *)signUpPermissionTypes
 {
@@ -96,7 +96,7 @@ typedef NS_ENUM(NSUInteger, APCPermissionsErrorCode) {
     if (self) {
         self.healthKitCharacteristicTypesToRead = characteristicTypesToRead;
         self.healthKitTypesToRead = quantityTypesToRead;
-        self.healthKitTypesToWrite = QuantityTypesToWrite;
+        self.healthKitTypesToWrite = quantityTypesToWrite;
         self.signUpPermissionTypes = signUpPermissionTypes;
         self.userInfoItemTypes = userInfoItemTypes;
     }

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.h
@@ -49,8 +49,10 @@ NS_ASSUME_NONNULL_BEGIN
 @required
 /** The onboarding manager for the app. */
 - (APCOnboardingManager *)onboardingManager;
+
 /** The permissions manager for the app. */
 - (APCPermissionsManager *)permissionsManager;
+
 @optional
 /**
  *  Kept for backwards compatibility: return the inclusion criteria scene.
@@ -91,6 +93,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithProvider:(id<APCOnboardingManagerProvider>)provider user:(APCUser * __nonnull)user;
 
 - (void)instantiateOnboardingForType:(APCOnboardingTaskType)type;
+
+/** Override point to create a custom permissions manager. By default returns the receiver provider's permission manager. */
+- (APCPermissionsManager *)createPermissionsManager;
 
 #pragma mark Onboarding
 

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
@@ -122,9 +122,13 @@ NSString * const kAPCOnboardingStoryboardName = @"APCOnboarding";
 
 - (APCPermissionsManager *)permissionsManager {
     if (!_permissionsManager) {
-        _permissionsManager = [self.provider permissionsManager];
+        _permissionsManager = [self createPermissionsManager];
     }
     return _permissionsManager;
+}
+
+- (APCPermissionsManager *)createPermissionsManager {
+    return [self.provider permissionsManager];
 }
 
 #pragma mark - APCOnboardingDelegate


### PR DESCRIPTION
Allows onboarding manager subclasses to create their own permissions manager, rather than having to use the one supplied by the app delegate. Adds documentation for the permissions manager designated initializer.
