### PR TITLE
Fix issue related to skipping of Custom Step

### DIFF
--- a/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
@@ -112,6 +112,7 @@
     
     APCScene *custom = [self.delegate onboarding:self sceneOfType:kAPCSignUpCustomInfoStepIdentifier];
     if (custom) {
+        self.onboardingTask.customStepIncluded = YES;
         scenes[kAPCSignUpCustomInfoStepIdentifier] = custom;
     }
     


### PR DESCRIPTION
## Overview

The custom step in onboarding was skipped after the new `APCOnboardingManager`.
## Actions
- Setting the `customStepIncluded` to `YES` during setup solves the issue.
