### PR TITLE
Encoding NSString from filePath HTML Content.

### DIFF
--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
@@ -238,7 +238,8 @@ static NSString *kConsentEmailSubject = @"Consent Document";
         
         NSString *filePath = [[NSBundle mainBundle] pathForResource: studyDetails.detailText ofType:@"html" inDirectory:@"HTMLContent"];
         NSAssert(filePath, @"Expecting file \"%@.html\" to be present in the \"HTMLContent\" directory, but didn't find it", studyDetails.detailText);
-        NSURL *targetURL = [NSURL URLWithString:filePath];
+        NSString *encodingFilePath = [filePath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        NSURL *targetURL = [NSURL URLWithString:encodingFilePath];
         NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
         [webViewCell.webView loadRequest:request];
         


### PR DESCRIPTION
Encoding NSString from file Path HTML Content, if any errors in String from file Path HTML, the file does not load.
