### PR TITLE
Replacing URLWithString: by fileURLWithPath:

### DIFF
--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
@@ -238,7 +238,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
         
         NSString *filePath = [[NSBundle mainBundle] pathForResource: studyDetails.detailText ofType:@"html" inDirectory:@"HTMLContent"];
         NSAssert(filePath, @"Expecting file \"%@.html\" to be present in the \"HTMLContent\" directory, but didn't find it", studyDetails.detailText);
-        NSURL *targetURL = [NSURL URLWithString:filePath];
+        NSURL *targetURL = [NSURL fileURLWithPath:filePath];
         NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
         [webViewCell.webView loadRequest:request];
         


### PR DESCRIPTION
Thus managed to avoid problems like build the URL with null values if the string contains spaces or special character.
