### PR TITLE
Fix wrong LessThanEqual op for APCSmartSurveyTask

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
@@ -403,7 +403,7 @@ static APCDummyObject * _dummyObject;
     }
     
     //Less Than or EqualTo
-    if ([operator isEqualToString:kOperatorGreaterThanEqual]) {
+    if ([operator isEqualToString:kOperatorLessThanEqual]) {
         if (answerNumber && valueNumber) {
             if ((answerDouble - valueDouble) < DBL_EPSILON) {
                 retValue = skipToValue;


### PR DESCRIPTION
Probably a typo, kOperatorGreaterThanEqual is used twice and
kOperatorLessThanEqual is clearly ignored.